### PR TITLE
adding annual energy output by heliostat to SSC outputs

### DIFF
--- a/solarpilot/AutoPilot_API.cpp
+++ b/solarpilot/AutoPilot_API.cpp
@@ -1957,6 +1957,28 @@ sp_optimize *AutoPilot::GetOptimizationObject()
     return _opt;
 }
 
+std::vector<double> AutoPilot::GetSFAnnualEnergy()
+{
+	std::vector<double> ann = {};
+	Hvector *hels = _SF->getHeliostats();
+	for (size_t i = 0; i < hels->size(); i++)
+	{
+		ann.push_back(hels->at(i)->getAnnualEnergy());
+	}
+	return ann;
+}
+
+std::vector<int> AutoPilot::GetHelioIDs()
+{
+	std::vector<int> ann = {};
+	Hvector *hels = _SF->getHeliostats();
+	for (size_t i = 0; i < hels->size(); i++)
+	{
+		ann.push_back(hels->at(i)->getId());
+	}
+	return ann;
+}
+
 void AutoPilot::PostEvaluationUpdate(int iter, vector<double> &pos, /*vector<double> &normalizers, */double &obj, double &flux, double &cost, std::string *note)
 {
 	ostringstream os;

--- a/solarpilot/AutoPilot_API.h
+++ b/solarpilot/AutoPilot_API.h
@@ -141,6 +141,8 @@ public:
 	bool IsSimulationCancelled();
     //other
     sp_optimize *GetOptimizationObject();
+	std::vector< double > GetSFAnnualEnergy();
+	std::vector< int > GetHelioIDs();
     
     struct API_CANT_TYPE { enum A {NONE, ON_AXIS, EQUINOX, SOLSTICE_SUMMER, SOLSTICE_WINTER }; };
 	

--- a/solarpilot/Heliostat.cpp
+++ b/solarpilot/Heliostat.cpp
@@ -88,6 +88,7 @@ double Heliostat::getEfficiencyCloudiness(){return eff_data.eta_cloud;}
 double Heliostat::getPowerToReceiver(){return eff_data.power_to_rec;}
 double Heliostat::getPowerValue(){return eff_data.power_value;}
 double Heliostat::getRankingMetricValue(){return eff_data.rank_metric;}
+double Heliostat::getAnnualEnergy() { return eff_data.energy_annual; }
 double Heliostat::getAzimuthTrack(){return _azimuth;}
 double Heliostat::getZenithTrack(){return _zenith;}
 double Heliostat::getCollisionRadius(){return _r_collision;}
@@ -126,6 +127,7 @@ void Heliostat::setEfficiencyShading(double eta_shadow){eff_data.eta_shadow = et
 void Heliostat::setEfficiencyCloudiness(double eta_cloud){eff_data.eta_cloud = eta_cloud;}
 void Heliostat::setEfficiencyTotal(double eta_tot){eff_data.eta_tot = eta_tot;}
 void Heliostat::setRankingMetricValue(double rval){eff_data.rank_metric = rval;}
+void Heliostat::setAnnualEnergy(double p_annual) { eff_data.energy_annual = p_annual; }
 void Heliostat::setAimPointFluxPlane(sp_point &Aim){_aim_fluxplane.Set( Aim.x, Aim.y, Aim.z );}
 void Heliostat::setAimPointFluxPlane(double x, double y, double z){ _aim_fluxplane.Set(x, y, z); }
 void Heliostat::setTrackVector(Vect &tr){ _track = tr; }	//Set the tracking vector

--- a/solarpilot/Heliostat.h
+++ b/solarpilot/Heliostat.h
@@ -164,6 +164,7 @@ public:
 	double getPowerToReceiver();
 	double getPowerValue();
 	double getRankingMetricValue();
+	double getAnnualEnergy();
 	double getAzimuthTrack();
 	double getZenithTrack();
     double getArea();
@@ -202,6 +203,7 @@ public:
 	void setEfficiencyCloudiness(double eta_cloud);
 	void setEfficiencyTotal(double eta_tot);
 	void setRankingMetricValue(double rval);
+	void setAnnualEnergy(double p_annual);
 	void setLocation(double x, double y, double z);
 	void setAimPoint(double x, double y, double z);
 	void setAimPoint(sp_point &Aim);

--- a/solarpilot/SolarField.cpp
+++ b/solarpilot/SolarField.cpp
@@ -1529,14 +1529,17 @@ void SolarField::ProcessLayoutResults( sim_results *results, int nsim_total){
 	    int rid = _var_map->sf.hsort_method.mapval();
 	
 	    nresults = (int)results->size();
-
+		double energy_ann = 0.;
         //compile the results from each simulation by heliostat
         for(int i=0; i<Npos; i++){
 		    int hid = _heliostats.at(i)->getId();	//use the heliostat ID from the first result to collect all of the other results
 		    rmet = 0.;      //ranking metric
-		    for(int j=0; j<nresults; j++)
-                rmet += results->at(j).data_by_helio[ hid ].getDataByIndex( rid );      //accumulate ranking metric as specified in rid
-
+			energy_ann = 0.; //annual energy output
+			for (int j = 0; j < nresults; j++)
+			{
+				rmet += results->at(j).data_by_helio[hid].getDataByIndex(rid);      //accumulate ranking metric as specified in rid
+				energy_ann += results->at(j).data_by_helio[hid].power_value; //W-hr
+			}
             //normalize for available heliostat power if applicable
             double afact = 1.;
             if( rid == helio_perf_data::PERF_VALUES::POWER_TO_REC || rid == helio_perf_data::PERF_VALUES::POWER_VALUE )
@@ -1545,6 +1548,7 @@ void SolarField::ProcessLayoutResults( sim_results *results, int nsim_total){
             double rank_val = rmet / (afact*(float)nresults);       //Calculate the normalized ranking metric. Divide by heliostat area if needed
 		
             _helio_by_id[hid]->setRankingMetricValue( rank_val );   //store the value
+			_helio_by_id[hid]->setAnnualEnergy(energy_ann);         //store annual energy
 		    hsort.at(i) = rank_val;                                 //also store in the sort array
 		
 	    }

--- a/solarpilot/heliodata.cpp
+++ b/solarpilot/heliodata.cpp
@@ -121,6 +121,9 @@ double helio_perf_data::getDataByIndex(const int id){
 		case helio_perf_data::PERF_VALUES::ETA_CLOUD:
 			rval = eta_cloud;
 			break;
+		case helio_perf_data::PERF_VALUES::ANNUAL_ENERGY:
+			rval = energy_annual;
+			break;
 		default:
 			rval = 0.;
 	}	
@@ -184,6 +187,7 @@ void helio_perf_data::resetMetrics(){
 	power_to_rec = 0.;
 	power_value = 0.;
 	rank_metric = 0.;
+	energy_annual = 0.;
 }
 
 double helio_perf_data::calcTotalEfficiency(){

--- a/solarpilot/heliodata.h
+++ b/solarpilot/heliodata.h
@@ -62,7 +62,7 @@ public:
 	//This enumeration is order specific based on the indices specified in the gui variable "solarfield.0.hsort_method"
 	struct PERF_VALUES { enum A {
 		POWER_TO_REC=0, ETA_TOT, ETA_COS, ETA_ATT, ETA_INT, ETA_BLOCK, ETA_SHADOW, POWER_VALUE, /* after this, order not significant */
-        REFLECTIVITY, SOILING, REC_ABSORPTANCE, RANK_METRIC, ETA_CLOUD };
+        REFLECTIVITY, SOILING, REC_ABSORPTANCE, RANK_METRIC, ETA_CLOUD, ANNUAL_ENERGY };
 	};
 	helio_perf_data();
 
@@ -85,8 +85,8 @@ public:
 		power_to_rec,	//[W] delivered power
 		power_value,
 		rank_metric,	//Power weighted by the payment allocation factor, if applicable
-		eta_cloud;	//[-] Loss due to cloudiness (performance simulation only)
-		
+		eta_cloud,	//[-] Loss due to cloudiness (performance simulation only)
+		energy_annual; //[Wh] estimated total annual energy
 };
 
 #endif

--- a/ssc/cmod_solarpilot.cpp
+++ b/ssc/cmod_solarpilot.cpp
@@ -154,6 +154,8 @@ static var_info _cm_vtab_solarpilot[] = {
     { SSC_OUTPUT,       SSC_NUMBER,      "cost_tower_tot",            "Total tower cost",                           "$",      "",         "SolarPILOT",   "*",                "",                "" },
     { SSC_OUTPUT,       SSC_NUMBER,      "cost_land_tot",             "Total land cost",                            "$",      "",         "SolarPILOT",   "*",                "",                "" },
     { SSC_OUTPUT,       SSC_NUMBER,      "cost_site_tot",             "Total site cost",                            "$",      "",         "SolarPILOT",   "*",                "",                "" },
+	{ SSC_OUTPUT,       SSC_ARRAY,       "annual_helio_energy",       "Heliostat annual energy collected",          "MWh",    "",         "SolarPILOT",   "*",                "",                "" },
+	{ SSC_OUTPUT,       SSC_ARRAY,       "helio_ids",                 "Heliostat identifiers",                      "",       "",         "SolarPILOT",   "*",                "",                "" },
 
 	var_info_invalid };
 
@@ -180,6 +182,9 @@ public:
 		std::shared_ptr<weather_data_provider> wdata = std::make_shared<weatherfile>(as_string("solar_resource_file"));
 		solarpilot_invoke spi( this );
 		spi.run(wdata);
+
+		std::vector<double> ann_energy = spi.GetSAPI()->GetSFAnnualEnergy();
+		std::vector<int> h_ids = spi.GetSAPI()->GetHelioIDs();
 
 		assign("h_tower_opt", (ssc_number_t)spi.sf.tht.val);
 		assign("rec_height_opt", (ssc_number_t)spi.recs.front().rec_height.val);
@@ -221,7 +226,13 @@ public:
 			assign("number_heliostats", (ssc_number_t)spi.layout.heliostat_positions.size());
         }
 
- 
+		ssc_number_t *hann = allocate("annual_helio_energy", ann_energy.size());
+		ssc_number_t *hids = allocate("helio_ids", ann_energy.size());
+		for (size_t i = 0; i < ann_energy.size(); i++)
+		{
+			hann[i] = (ssc_number_t)ann_energy.at(i);
+			hids[i] = (ssc_number_t)h_ids.at(i);
+		}
 		
 		//return the land area
 		assign("base_land_area", (ssc_number_t)spi.land.land_area.Val());


### PR DESCRIPTION
The energy output by heliostat is required by DAO-tk's optical model, so this pull request wil add the required outputs to SSC.  Otherwise, the annual energy by heliostat is set to zero, which will (1) lead to one wash crew, rather than an optimized number, and (2) yield constant replacement in the heliostat degradation/replacement model.