### PR TITLE
Bug fix to loading and updating calculated values for receiver templates

### DIFF
--- a/solarpilot/IOUtil.cpp
+++ b/solarpilot/IOUtil.cpp
@@ -358,6 +358,7 @@ void ioutil::parseXMLInputFile(const string &fname,var_map &V, parametric &par_d
     
     vector<int> rec_insts;
     vector<int> hel_insts;
+    std::map< int, std::string > rec_offset_assignments;  //we'll need to save this info for after all templates have been loaded
 
 	//Read in all of the variables
 	xml_node<> *var_node = top_node->first_node("variable");
@@ -384,6 +385,8 @@ void ioutil::parseXMLInputFile(const string &fname,var_map &V, parametric &par_d
                     rec_insts.push_back( inst );
                 }
             }
+            if (varname == "rec_offset_reference")
+                rec_offset_assignments[inst] = var_node->first_node("value")->value();
         }
         if(component == "heliostat")
         {
@@ -426,6 +429,23 @@ void ioutil::parseXMLInputFile(const string &fname,var_map &V, parametric &par_d
 
 		var_node = var_node->next_sibling("variable");
 	}
+
+    //clean up template based parameters that may not have loaded correctly
+    for (size_t i = 0; i < V.recs.size(); i++)
+    {
+        V.recs[i].rec_offset_reference.combo_clear();
+        V.recs[i].rec_offset_reference.combo_add_choice("Tower", std::to_string(var_receiver::REC_OFFSET_REFERENCE::TOWER));
+
+        for (size_t j = 0; j < V.recs.size(); j++)
+        {
+            if (i == j)
+                continue;
+
+            V.recs[i].rec_offset_reference.combo_add_choice(V.recs[j].rec_name.as_string(), V.recs[j].id.as_string());
+        }
+        
+        V.recs[i].rec_offset_reference.combo_select(rec_offset_assignments[V.recs[i].id.val]);
+    }
 
 	//Read in any parametric data
 	par_data.clear();

--- a/solarpilot/SolarField.cpp
+++ b/solarpilot/SolarField.cpp
@@ -508,12 +508,14 @@ void SolarField::updateCalculatedParameters( var_map &V )
                 V.recs[i].rec_offset_x_global.Setval(std::numeric_limits<double>::quiet_NaN());
                 V.recs[i].rec_offset_y_global.Setval(std::numeric_limits<double>::quiet_NaN());
                 V.recs[i].rec_offset_z_global.Setval(std::numeric_limits<double>::quiet_NaN());
+                V.recs[i].optical_height.Setval(std::numeric_limits<double>::quiet_NaN());
             }
             else
             {
                 V.recs[i].rec_offset_x_global.Setval(og_x);
                 V.recs[i].rec_offset_y_global.Setval(og_y);
                 V.recs[i].rec_offset_z_global.Setval(og_z);
+                V.recs[i].optical_height.Setval(V.sf.tht.val + og_z);
             }
         }
     }
@@ -556,7 +558,7 @@ void SolarField::updateAllCalculatedParameters(var_map &V)
 
     _land.updateCalculatedParameters(V);
 
-    for( int i=0; i<(int)_receivers.size(); i++)
+    for( int i=0; i<(int)V.recs.size(); i++)
         _receivers.at(i)->updateCalculatedParameters(V.recs.at(i), V.sf.tht.val );
 
     _fluxsim.updateCalculatedParameters(V);


### PR DESCRIPTION
When loading spt files with multiple receivers, the receiver geometries were not correctly updated, nor were calculated parameters handled consistently for receivers beyond the first template. 