### PR TITLE
Additional Buie fixes

### DIFF
--- a/solarpilot/Ambient.cpp
+++ b/solarpilot/Ambient.cpp
@@ -115,7 +115,7 @@ void Ambient::calcBuieCSRIntensity(std::vector<double>& angle, std::vector<doubl
     angle.clear();
     intensity.clear();
 
-    double theta = -dt_cs; //set so first adjustment is back to 0
+    double theta = -dt_s; //set so first adjustment is back to 0
 
     while(theta < angle_max)
     {

--- a/solarpilot/interop.cpp
+++ b/solarpilot/interop.cpp
@@ -1224,6 +1224,7 @@ void sim_result::process_raytrace_simulation(SolarField &SF, sim_params &P, int 
 
         eff_total_sf.set(0,0, 0, 0, 0., power_absorbed / power_on_field);
         eff_cosine.set(0.,0., 0., 0., 0., (double)nhin / (double)nsunrays*Abox / total_heliostat_area);
+        eff_shading.set(1., 1., 1., 0., 1., 1.);        //shading is accounted for in the blocking calculation
 		eff_blocking.set(0.,0., 0., 0., 0., 1. - (double)nhblock / (double)(nhin - nhabs));
 		eff_attenuation.set(0., 0., 0., 0., 0., 1.);	//Not currently accounted for
 		eff_reflect.set(0., 0., 0., 0., 0., (double)(nhin - nhabs) / (double)nhin);


### PR DESCRIPTION
Additional fixes for Buie sunshape model based on SolarPACES comparison. This limits the maximum extent angle for the analytical lookup table to 20 mrad to avoid overfitting the larger displacement angles. With this fix, the analytical model creates a better representation of Buie sunshape, especially with zero optical error in the heliostats.