### PR TITLE
Modifications for variable time steps in real-time dispatch model and (older) changes to lpsolve constraints

### DIFF
--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -326,8 +326,7 @@ static var_info _cm_vtab_tcsmolten_salt[] = {
     { SSC_INPUT,		SSC_MATRIX,		 "fc_dni_scenarios",	 "Forecast DNI scenarios",					                          "W/m2",		  "",			 "sys_ctrl_disp_opt", "",						 "",					  "" },
     { SSC_INPUT,		SSC_MATRIX,		 "fc_price_scenarios",	 "Forecast price scenarios",					                      "-",		      "",			 "sys_ctrl_disp_opt", "",						 "",					  "" },
     { SSC_INPUT,		SSC_MATRIX,		 "fc_tdry_scenarios",	 "Forecast dry bulb temperature scenarios",                           "C",		      "",			 "sys_ctrl_disp_opt", "",						 "",					  "" },
-    //{ SSC_INPUT,		SSC_NUMBER,		 "fc_steps",	         "Number of time steps per forecast block",                           "-",		      "",			 "sys_ctrl_disp_opt", "",						 "",					  "" },
-    { SSC_INPUT,        SSC_NUMBER,      "fc_gamma",             "Forecast uncertainty TES hedging factor"                            "-",            "",            "sys_ctrl_disp_opt","?=0",                      "",                      "" },
+    { SSC_INPUT,        SSC_NUMBER,      "fc_gamma",             "Forecast uncertainty TES hedging factor",                            "-",            "",           "sys_ctrl_disp_opt", "?=0.",                    "",                      "" },
 
 	{ SSC_INPUT,		SSC_NUMBER,		 "allow_controller_exceptions",   "Allow controller exceptions? (1 = true)",				  "-",		      "",			 "sys_ctrl",		 "?=1",						 "",					  "" },
 	{ SSC_INPUT,		SSC_ARRAY,		 "select_simulation_days",   "Selected subset of simulation days",							  "-",		      "",			 "sys_ctrl",		 "?=0",						 "",					  "" },
@@ -343,25 +342,30 @@ static var_info _cm_vtab_tcsmolten_salt[] = {
 	{ SSC_INPUT,		SSC_ARRAY,		 "is_pc_su_allowed_in",  "User-provided is power cycle startup allowed?",					  "-",			  "",			 "sys_ctrl",		 "is_dispatch_targets=1",	 "",					  "" },
 	{ SSC_INPUT,		SSC_ARRAY,		 "is_pc_sb_allowed_in",  "User-provided is power cycle standby allowed?",					  "-",			  "",			 "sys_ctrl",		 "is_dispatch_targets=1",	 "",					  "" },
 
-	{ SSC_INPUT,		SSC_NUMBER,		 "is_dispatch_constr",	 "Use dispatch capacity/efficiency constraints?",					  "-",		      "",			 "sys_ctrl",		 "?=0",						 "",					  "" },
-	{ SSC_INPUT,		SSC_ARRAY,		 "disp_cap_constr",		 "Fraction of turbine capacity available",							  "-",			  "",			 "sys_ctrl",		 "is_dispatch_constr=1",	 "",					  "" },
-	{ SSC_INPUT,		SSC_ARRAY,		 "disp_eff_constr",		 "Fraction of design point turbine efficiency available",			  "-",			  "",			 "sys_ctrl",		 "is_dispatch_constr=1",	 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "is_dispatch_constr",	 "Use dispatch capacity/efficiency constraints?",					  "-",		      "",			 "sys_ctrl_disp_opt",	"?=0",					 "",					  "" },
+	{ SSC_INPUT,		SSC_ARRAY,		 "disp_cap_constr",		 "Fraction of turbine capacity available",							  "-",			  "",			 "sys_ctrl_disp_opt",	"is_dispatch_constr=1",	 "",					  "" },
+	{ SSC_INPUT,		SSC_ARRAY,		 "disp_eff_constr",		 "Fraction of design point turbine efficiency available",			  "-",			  "",			 "sys_ctrl_disp_opt",	"is_dispatch_constr=1",	 "",					  "" },
 
 	
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_rampup",		 "Cycle max ramp up (fraction of capacity per hour)",				  "-",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_rampdown",	 "Cycle max ramp down (fraction of capacity per hour)",				  "-",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_minup",		 "Cycle minimum up time",											  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_mindown",		 "Cycle minimum down time",											  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_rampup",		 "Cycle max ramp up (fraction of capacity per minute)",				  "-",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_rampdown",	 "Cycle max ramp down (fraction of capacity per minute)",			  "-",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },	
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_rampup_vl",	 "Cycle ramp up violation limit (fraction of capacity per minute)",	        "-",	  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_rampdown_vl",	 "Cycle max ramp down violation limit (fraction of capacity per minute)",	"-",	  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_minup",		 "Cycle minimum up time",											  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_mindown",		 "Cycle minimum down time",											  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
 
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_perm",   "Permanence of cycle on/off/standby decisions",					  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_la_perm", "Permanence of cycle on/off/standby decisions during lookahead ",	  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_level_perm",   "Permanence of cycle operating level decisions",					  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_level_la_perm",  "Permanence of cycle operating level decisions during lookahead",  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_rec_onoff_perm",   "Permanence of receiver on/off decisions",						  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_rec_onoff_la_perm", "Permanence of receiver on/off decisions during lookahead ",		  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_perm",    "Permanence of cycle on/off/standby decisions",					  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_la_perm", "Permanence of cycle on/off/standby decisions during lookahead ",	  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_level_perm",    "Permanence of cycle operating level decisions",					  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_level_la_perm", "Permanence of cycle operating level decisions during lookahead",  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_rec_onoff_perm",   "Permanence of receiver on/off decisions",						  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_rec_onoff_la_perm", "Permanence of receiver on/off decisions during lookahead ",		  "hr",			  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
 
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_storage_buffer",   "Minimum allowable storage in dispatch model (fraction of capacity)",	 "",		  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_storage_buffer",   "Minimum allowable storage in dispatch model (fraction of capacity)",	 "",		  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
 
+	{ SSC_INPUT,		SSC_ARRAY,		 "disp_steplength_array",     "Dispatch time step lengths (min)",							  "min",		  "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_ARRAY,		 "disp_steplength_end_time",  "End time for dispatch step lengths (hr)",					  "hr",		      "",			 "sys_ctrl_disp_opt",	"?=0.",					 "",					  "" },
 
 
 
@@ -1674,84 +1678,108 @@ public:
             tou.mc_dispatch_params.m_is_stochastic_dispatch = as_boolean("is_stochastic_dispatch");
 
 
+			// Variable step-lengths for real-time dispatch model
+			size_t nsteplengths = 0;
+			size_t nh = 0;
+			ssc_number_t* disp_steplengths = as_array("disp_steplength_array", &nsteplengths);
+			ssc_number_t* disp_steplength_end_time = as_array("disp_steplength_end_time", &nh);
+
+			if (nsteplengths == 1 && disp_steplengths[0] < 1.e-6)  // Default time-step arrays -> Use constant time step input
+			{
+				tou.mc_dispatch_params.m_is_variable_disp_steps = false;
+				tou.mc_dispatch_params.m_disp_steplength_array = { 60. / tou.mc_dispatch_params.m_disp_steps_per_hour };
+				tou.mc_dispatch_params.m_disp_steplength_end_time = { (double)tou.mc_dispatch_params.m_optimize_horizon };
+			}
+			else
+			{
+				if (nsteplengths != nh)
+					throw exec_error("tcsmolten_salt", "Dimensions of 'disp_steplength_array' and 'disp_steplength_end_time' must be the same");
+
+				if (disp_steplength_end_time[nsteplengths - 1] < tou.mc_dispatch_params.m_optimize_horizon)
+					throw exec_error("tcsmolten_salt", "Last entry of 'disp_steplength_end_time' is shorter than disp_horizon");
+				
+				tou.mc_dispatch_params.m_is_variable_disp_steps = true;
+				tou.mc_dispatch_params.m_disp_steps_per_hour = std::numeric_limits<int>::quiet_NaN();
+
+				int wf_step = (int)(8760. * 60. / (double)n_steps_full);   // Weather file time step [min]
+				tou.mc_dispatch_params.m_disp_steplength_array.resize(nsteplengths);
+				tou.mc_dispatch_params.m_disp_steplength_end_time.resize(nsteplengths);
+				for (int i = 0; i < nsteplengths; i++)
+				{
+					tou.mc_dispatch_params.m_disp_steplength_array.at(i) = disp_steplengths[i];
+					tou.mc_dispatch_params.m_disp_steplength_end_time.at(i) = disp_steplength_end_time[i];
+					if ((int)disp_steplengths[i] % wf_step > 0)
+						throw exec_error("tcsmolten_salt", "All entries of 'disp_steplength_array' must be an integer multiple of the weather file time step");
+				}
+			}
+
+
+			// Cycle maximum ramp-up and ramp-down rates 
+			tou.mc_dispatch_params.m_pc_max_rampup = as_double("disp_pc_rampup") > 1.e-6 ? as_double("disp_pc_rampup") * 60. : 60.;  // fraction of capacity per hour (set to 100% per minute if not specified)
+			tou.mc_dispatch_params.m_pc_max_rampdown = as_double("disp_pc_rampdown") > 1.e-6 ? as_double("disp_pc_rampdown") * 60. : 60.;
+			tou.mc_dispatch_params.m_pc_rampup_violation_lim = as_double("disp_pc_rampup_vl") * 60.;    // maximum ramp-up violation limit in fraction of capacity per hour
+			tou.mc_dispatch_params.m_pc_rampdown_violation_lim = as_double("disp_pc_rampdown_vl") * 60.;
+
+
+			// Dispatch storage buffer
+			tou.mc_dispatch_params.m_storage_buffer = as_double("disp_storage_buffer");
 
 			// Cycle minimum up- and down-times (hr)
 			tou.mc_dispatch_params.m_pc_minup = as_double("disp_pc_minup"); 
 			tou.mc_dispatch_params.m_pc_mindown = as_double("disp_pc_mindown");
 
-			// Decision permanence (hr)
-			double pc_onoff = as_double("disp_pc_onoff_perm");
-			double pc_onoff_lookahead = as_double("disp_pc_onoff_la_perm");
-			double pc_level = as_double("disp_pc_level_perm");
-			double pc_level_lookahead = as_double("disp_pc_level_la_perm");
-			double rec_onoff = as_double("disp_rec_onoff_perm");
-			double rec_onoff_lookahead = as_double("disp_rec_onoff_la_perm");
 			
-			vector<double> perm = {pc_onoff, pc_onoff_lookahead, pc_level, pc_level_lookahead, rec_onoff, rec_onoff_lookahead};
-			double disp_opt_ts = 1. / (float)tou.mc_dispatch_params.m_disp_steps_per_hour;  // User-specfied dispatch time step (hr)
-			double min_decision = disp_opt_ts;   
-			for (int i = 0; i < perm.size(); i++)   
+			
+			// Decision permanence (hr)
+			if (!tou.mc_dispatch_params.m_is_variable_disp_steps)
 			{
-				if (perm.at(i) == 0.)  
-					perm.at(i) = disp_opt_ts;
+				double pc_onoff = as_double("disp_pc_onoff_perm");
+				double pc_onoff_lookahead = as_double("disp_pc_onoff_la_perm");
+				double pc_level = as_double("disp_pc_level_perm");
+				double pc_level_lookahead = as_double("disp_pc_level_la_perm");
+				double rec_onoff = as_double("disp_rec_onoff_perm");
+				double rec_onoff_lookahead = as_double("disp_rec_onoff_la_perm");
 
-				min_decision = min(min_decision, perm.at(i));
-				for (int j = 0; j < i; j++)
+				vector<double> perm = { pc_onoff, pc_onoff_lookahead, pc_level, pc_level_lookahead, rec_onoff, rec_onoff_lookahead };
+				double disp_opt_ts = 1. / (float)tou.mc_dispatch_params.m_disp_steps_per_hour;  // User-specfied dispatch time step (hr)
+				double min_decision = disp_opt_ts;
+				for (int i = 0; i < perm.size(); i++)
 				{
-					double diff = fabs(perm.at(i) - perm.at(j));
-					if (diff > 0. && diff < min_decision)
-						min_decision = diff;
+					if (perm.at(i) == 0.)
+						perm.at(i) = disp_opt_ts;
+
+					min_decision = min(min_decision, perm.at(i));
+					for (int j = 0; j < i; j++)
+					{
+						double diff = fabs(perm.at(i) - perm.at(j));
+						if (diff > 0. && diff < min_decision)
+							min_decision = diff;
+					}
 				}
+
+				if (disp_opt_ts > min_decision)  // Reset dispatch optimization timestep if necessary
+				{
+					log(util::format("\nThe dispatch time step was reset from the user-specified value (%.2f hr) to the minimum"
+						"allowable value from decision permanence specifications (%.2f hr)", disp_opt_ts, min_decision), SSC_WARNING);
+					disp_opt_ts = min_decision;
+					tou.mc_dispatch_params.m_disp_steps_per_hour = (int)floor(1. / disp_opt_ts);
+				}
+				tou.mc_dispatch_params.m_pc_onoff_perm = (pc_onoff > 0.) ? pc_onoff : disp_opt_ts;  // Default to dispatch optimization timestep if not specified
+				tou.mc_dispatch_params.m_pc_level_perm = (pc_level > 0.) ? pc_level : disp_opt_ts;
+				tou.mc_dispatch_params.m_rec_onoff_perm = (rec_onoff > 0.) ? rec_onoff : disp_opt_ts;
+
+				// Look-ahead period decision permanence: Always set to be >= that in optimization period
+				tou.mc_dispatch_params.m_pc_onoff_lookahead_perm = fmax(tou.mc_dispatch_params.m_pc_onoff_perm, pc_onoff_lookahead);
+				tou.mc_dispatch_params.m_pc_level_lookahead_perm = fmax(tou.mc_dispatch_params.m_pc_level_perm, pc_level_lookahead);
+				tou.mc_dispatch_params.m_rec_onoff_lookahead_perm = fmax(tou.mc_dispatch_params.m_rec_onoff_perm, rec_onoff_lookahead);
 			}
 
-			if (disp_opt_ts > min_decision)  // Reset dispatch optimization timestep if necessary
-			{
-				log(util::format("\nThe dispatch time step was reset from the user-specified value (%.2f hr) to the minimum"
-					"allowable value from decision permanence specifications (%.2f hr)", disp_opt_ts, min_decision), SSC_WARNING);
-				disp_opt_ts = min_decision;
-				tou.mc_dispatch_params.m_disp_steps_per_hour = (int)floor(1. / disp_opt_ts);
-			}
-			tou.mc_dispatch_params.m_pc_onoff_perm = (pc_onoff > 0.) ? pc_onoff : disp_opt_ts;  // Default to dispatch optimization timestep if not specified
-			tou.mc_dispatch_params.m_pc_level_perm = (pc_level > 0.) ? pc_level : disp_opt_ts;
-			tou.mc_dispatch_params.m_rec_onoff_perm = (rec_onoff > 0.) ? rec_onoff : disp_opt_ts;
-
-			// Look-ahead period decision permanence: Always set to be >= that in optimization period
-			tou.mc_dispatch_params.m_pc_onoff_lookahead_perm = fmax(tou.mc_dispatch_params.m_pc_onoff_perm, pc_onoff_lookahead); 
-			tou.mc_dispatch_params.m_pc_level_lookahead_perm = fmax(tou.mc_dispatch_params.m_pc_level_perm, pc_level_lookahead);
-			tou.mc_dispatch_params.m_rec_onoff_lookahead_perm = fmax(tou.mc_dispatch_params.m_rec_onoff_perm, rec_onoff_lookahead);
 
 
 
-			// Cycle maximum ramp-up and ramp-down rates (fraction of total capacity per hour)
-			double rampup = as_double("disp_pc_rampup");
-			double rampdown = as_double("disp_pc_rampdown");
-			if (rampup < 1.e-6) // Unconstrained ramp-up
-				rampup = 60.;
-			if (rampdown < 1.e-6) // Unconstrained ramp-down
-				rampdown = 60.;
-			tou.mc_dispatch_params.m_pc_max_rampup = rampup;
-			tou.mc_dispatch_params.m_pc_max_rampdown = rampdown;
 
 
-			double rampup_per_step = rampup / (float)tou.mc_dispatch_params.m_disp_steps_per_hour;  // fraction of capacity per dispatch time step
-			double rampdown_per_step = rampdown / (float)tou.mc_dispatch_params.m_disp_steps_per_hour;  // fraction of capacity per dispatch time step
-			if (rampup_per_step < as_double("cycle_cutoff_frac"))
-			{
-				log(util::format("\nThe maximum allowable upward change in cycle thermal input per dispatch timestep (%.0f%% of capacity) is less than then minimum operational level (%.0f%% of capacity)."
-					" The maximum ramp-up constraint will not be enforced when the cycle starts up", rampup_per_step*100, as_double("cycle_cutoff_frac")*100), SSC_WARNING);
-			}
-			if (rampdown_per_step < as_double("cycle_cutoff_frac"))
-			{
-				log(util::format("\nThe maximum allowable downward change in cycle thermal input per dispatch timestep (%.0f%% of capacity) is less than then minimum operational level (%.0f%% of capacity)."
-					" The maximum ramp-down constraint will not be enforced when the cycle shuts down", rampdown_per_step*100, as_double("cycle_cutoff_frac")*100), SSC_WARNING);
-			}
-					
-			// Dispatch storage buffer
-			tou.mc_dispatch_params.m_storage_buffer = as_double("disp_storage_buffer");
-
-
-
-			if (as_boolean("is_wlim_series"))
+			if (as_boolean("is_wlim_series"))  // Defined at same time resolution as weather file
 			{
 				size_t n_wlim_series = 0;
 				ssc_number_t* wlim_series = as_array("wlim_series", &n_wlim_series);
@@ -1818,13 +1846,15 @@ public:
 				int n_opt_periods = (int)ceil(8760. / (double)opt_freq);			// optimizations per year
 				int n_opt_per_update = horizon_update / opt_freq;					// optimizations per horizon update 
 				int n_hour_per_update = (n_opt_per_update * opt_horizon) - opt_freq * (n_opt_per_update*(n_opt_per_update - 1) / 2);	// hours in scenarios per horizon update
-				int nstep = tou.mc_dispatch_params.m_disp_steps_per_hour * n_hour_per_update * n_update_periods;
+				
+				int wf_steps_per_hour = (int)n_steps_full / 8760;
+				int nstep = wf_steps_per_hour * n_hour_per_update * n_update_periods;
 
 				if (n_opt_periods < n_update_periods * n_opt_per_update)  
 				{
 					int n_opt_last_update = n_opt_periods - (n_update_periods - 1) * n_opt_per_update;  // optimizations in last horizon udpate
 					int n_hour_last_update = (n_opt_last_update * opt_horizon) - opt_freq * (n_opt_last_update*(n_opt_last_update - 1) / 2);
-					nstep = tou.mc_dispatch_params.m_disp_steps_per_hour * (n_hour_per_update * (n_update_periods - 1) + n_hour_last_update);  // expected steps in scenario files 
+					nstep = wf_steps_per_hour * (n_hour_per_update * (n_update_periods - 1) + n_hour_last_update);  // expected steps in scenario files 
 				}
 
 				if (tou.mc_dispatch_params.m_is_dni_scenarios && tou.mc_dispatch_params.m_fc_dni_scenarios.nrows() != nstep)
@@ -1853,7 +1883,7 @@ public:
 		}
 
 
-		// User-specified dispatch targets
+		// User-specified dispatch targets (specified at weather-file resolution)
 		bool is_dispatch_targets = as_boolean("is_dispatch_targets");
 		if (is_dispatch_targets && tou.mc_dispatch_params.m_dispatch_optimize)
 		{
@@ -1905,7 +1935,7 @@ public:
 				
 		}
 
-		// Dispatch optimization capacity/efficiency constraints
+		// Dispatch optimization capacity/efficiency constraints (specifed at weather-file time resolution)
 		tou.mc_dispatch_params.m_is_disp_constr = as_boolean("is_dispatch_constr");
 		if (tou.mc_dispatch_params.m_is_disp_constr)
 		{

--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -355,6 +355,8 @@ static var_info _cm_vtab_tcsmolten_salt[] = {
 
 	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_perm",   "Permanence of cycle binary on/off decisions",						  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
 	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_level_perm",   "Permanence of cycle operating level decisions",					  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
+	
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_la_perm", "Permanence of cycle binary on/off decisions during lookahead ",	  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
 
 
 
@@ -1694,15 +1696,21 @@ public:
 				}
 			}
 
-			if (disp_opt_ts > min_decision)  // Reset dispatch optmization timestep if necessary
+			if (disp_opt_ts > min_decision)  // Reset dispatch optimization timestep if necessary
 			{
 				log(util::format("\nThe dispatch time step was reset from the user-specified value (%.2f hr) to the minimum"
-					"allowable value from decision permanence specifications (%.2f min)", disp_opt_ts, min_decision), SSC_WARNING);
+					"allowable value from decision permanence specifications (%.2f hr)", disp_opt_ts, min_decision), SSC_WARNING);
 				disp_opt_ts = min_decision;
 				tou.mc_dispatch_params.m_disp_steps_per_hour = (int)floor(1. / disp_opt_ts);
 			}
-			tou.mc_dispatch_params.m_pc_onoff_perm = (pc_onoff > 0.) ? pc_onoff : disp_opt_ts;
+			tou.mc_dispatch_params.m_pc_onoff_perm = (pc_onoff > 0.) ? pc_onoff : disp_opt_ts;  // Default to dispatch optimization timestep if not specified
 			tou.mc_dispatch_params.m_pc_level_perm = (pc_level > 0.) ? pc_level : disp_opt_ts;
+
+			
+			// Look-ahead period decision permanence
+			tou.mc_dispatch_params.m_pc_onoff_lookahead_perm = fmax(tou.mc_dispatch_params.m_pc_onoff_perm, as_double("disp_pc_onoff_la_perm")); // Decision permanence in look-ahead always >= that in optimization window
+
+
 
 
 			// Cycle maximum ramp-up and ramp-down rates (fraction of total capacity per hour)

--- a/ssc/cmod_tcsmolten_salt.cpp
+++ b/ssc/cmod_tcsmolten_salt.cpp
@@ -354,9 +354,10 @@ static var_info _cm_vtab_tcsmolten_salt[] = {
 	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_mindown",		 "Cycle minimum down time",											  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
 
 	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_perm",   "Permanence of cycle binary on/off decisions",						  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_la_perm", "Permanence of cycle binary on/off decisions during lookahead ",	  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
 	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_level_perm",   "Permanence of cycle operating level decisions",					  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
 	
-	{ SSC_INPUT,		SSC_NUMBER,		 "disp_pc_onoff_la_perm", "Permanence of cycle binary on/off decisions during lookahead ",	  "hr",			  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
+	{ SSC_INPUT,		SSC_NUMBER,		 "disp_storage_buffer",   "Minimum allowable storage in dispatch model (fraction of capacity)",	 "",		  "",			 "sys_ctrl",		 "?=0.",					 "",					  "" },
 
 
 
@@ -1737,7 +1738,8 @@ public:
 					" The maximum ramp-down constraint will not be enforced when the cycle shuts down", rampdown_per_step*100, as_double("cycle_cutoff_frac")*100), SSC_WARNING);
 			}
 					
-
+			// Dispatch storage buffer
+			tou.mc_dispatch_params.m_storage_buffer = as_double("disp_storage_buffer");
 
 
 

--- a/tcs/csp_dispatch.cpp
+++ b/tcs/csp_dispatch.cpp
@@ -186,9 +186,13 @@ csp_dispatch_opt::csp_dispatch_opt()
     //parameters
     params.is_pb_operating0 = false;
     params.is_pb_standby0 = false;
+	params.is_pb_startup0 = false;
     params.is_rec_operating0 = false;
+	params.is_rec_startup0 = false;
     params.q_pb0 = std::numeric_limits<double>::quiet_NaN();
     params.w_pb0 = std::numeric_limits<double>::quiet_NaN();
+	params.u_csu0 = std::numeric_limits<double>::quiet_NaN();
+	params.u_rsu0 = std::numeric_limits<double>::quiet_NaN();
     params.dt = std::numeric_limits<double>::quiet_NaN();
     params.e_tes_init = std::numeric_limits<double>::quiet_NaN();          
     params.e_tes_min = std::numeric_limits<double>::quiet_NaN();           
@@ -576,11 +580,11 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
         pars["Wht"] = optinst->params.w_rec_ht;
         pars["eta_cycle"] = optinst->params.eta_cycle_ref;
         pars["Qrsd"] = 0.;      //<< not yet modeled, passing temporarily as zero
-
+		pars["Qrsb"] = 1.e99;   // receiver standby not yet modeled, passing temporarily as infinite
 
         pars["s0"] = optinst->params.e_tes_init ;
-        pars["ursu0"] = 0.;
-        pars["ucsu0"] = 0.;
+		pars["ursu0"] = optinst->params.u_rsu0; 
+		pars["ucsu0"] = optinst->params.u_csu0;
         pars["y0"] = (optinst->params.is_pb_operating0 ? 1 : 0) ;
         pars["ycsb0"] = (optinst->params.is_pb_standby0 ? 1 : 0) ;
         pars["q0"] =  optinst->params.q_pb0 ;
@@ -588,8 +592,8 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
         
 		pars["yr0"] = (optinst->params.is_rec_operating0 ? 1 : 0);
 		pars["yrsb0"] = 0;
-		pars["yrsu0"] = 0;
-		pars["ycsu0"] = 0; 
+		pars["yrsu0"] = (optinst->params.is_rec_startup0 ? 1 : 0);
+		pars["ycsu0"] = (optinst->params.is_pb_startup0 ? 1 : 0);
 		
 		pars["deltal"] = optinst->params.dt_rec_startup;
 		

--- a/tcs/csp_dispatch.cpp
+++ b/tcs/csp_dispatch.cpp
@@ -580,20 +580,21 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
         pars["Wht"] = optinst->params.w_rec_ht;
         pars["eta_cycle"] = optinst->params.eta_cycle_ref;
         pars["Qrsd"] = 0.;      //<< not yet modeled, passing temporarily as zero
-		pars["Qrsb"] = 1.e99;   // receiver standby not yet modeled, passing temporarily as infinite
 
-        pars["s0"] = optinst->params.e_tes_init ;
-		pars["ursu0"] = optinst->params.u_rsu0; 
-		pars["ucsu0"] = optinst->params.u_csu0;
-        pars["y0"] = (optinst->params.is_pb_operating0 ? 1 : 0) ;
-        pars["ycsb0"] = (optinst->params.is_pb_standby0 ? 1 : 0) ;
-        pars["q0"] =  optinst->params.q_pb0 ;
-        pars["Wdot0"] = optinst->params.w_pb0;
         
+		pars["s0"] = optinst->params.e_tes_init;
+
+		pars["y0"] = (optinst->params.is_pb_operating0 ? 1 : 0);
+		pars["ycsb0"] = (optinst->params.is_pb_standby0 ? 1 : 0);
+		pars["ycsu0"] = (optinst->params.is_pb_startup0 ? 1 : 0);
+		pars["q0"] = optinst->params.q_pb0;
+		pars["Wdot0"] = optinst->params.w_pb0;
+		pars["ucsu0"] = optinst->params.u_csu0;
+
 		pars["yr0"] = (optinst->params.is_rec_operating0 ? 1 : 0);
 		pars["yrsb0"] = 0;
 		pars["yrsu0"] = (optinst->params.is_rec_startup0 ? 1 : 0);
-		pars["ycsu0"] = (optinst->params.is_pb_startup0 ? 1 : 0);
+		pars["ursu0"] = optinst->params.u_rsu0;
 		
 		pars["deltal"] = optinst->params.dt_rec_startup;
 		
@@ -602,7 +603,7 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
         for(int i=0; i<(int)optinst->outputs.q_sfavail_expected.nrows(); i++)
             pars["qrecmaxobs"] = optinst->outputs.q_sfavail_expected.at(i,0) > pars["qrecmaxobs"] ? optinst->outputs.q_sfavail_expected.at(i,0) : pars["qrecmaxobs"];
 
-        pars["Qrsb"] = optinst->params.q_rec_standby; // * dq_rsu;     //.02
+		pars["Qrsb"] = 1.e99; //optinst->params.q_rec_standby; // * dq_rsu;     //.02
         pars["M"] = 1.e6;
         pars["W_dot_cycle"] = optinst->params.q_pb_des * optinst->params.eta_cycle_ref;
 		

--- a/tcs/csp_dispatch.cpp
+++ b/tcs/csp_dispatch.cpp
@@ -214,7 +214,9 @@ csp_dispatch_opt::csp_dispatch_opt()
     params.eta_cycle_ref = std::numeric_limits<double>::quiet_NaN();
     params.disp_time_weighting = std::numeric_limits<double>::quiet_NaN();
     params.rsu_cost = params.csu_cost = params.pen_delta_w = params.q_rec_standby = std::numeric_limits<double>::quiet_NaN();
-    
+
+	params.is_uniform_dt = true;
+
     outputs.objective = 0.;
     outputs.objective_relaxed = 0.;
     outputs.solve_iter = 0;
@@ -251,7 +253,6 @@ void csp_dispatch_opt::clear_output_arrays()
     outputs.wnet_lim_min.clear();
     outputs.delta_rs.clear();
 	outputs.Qc.clear();
-
 	outputs.s_min.clear();
 }
 
@@ -272,12 +273,158 @@ bool csp_dispatch_opt::copy_weather_data(C_csp_weatherreader &weather_source)
     return m_is_weather_setup = true;
 }
 
-bool csp_dispatch_opt::predict_performance(int step_start, int ntimeints, int divs_per_int)
+
+bool csp_dispatch_opt::set_up_timestep_array(double horizon, const std::vector<double>& steplengths, const std::vector<double>& steplength_end_time)
+{
+	dt_array.clear();
+	t_elapsed.clear();
+	t_weight.clear();
+
+	size_t n = steplengths.size();
+	double time = 0.0;
+	int nsteps = 0;	
+	for (int j = 0; j < n; j++)
+	{
+		double dt = steplengths.at(j) / 60.;   // Steplength [hr]
+		double time_end = std::fmin(horizon, steplength_end_time.at(j));
+
+		int ns = (int)ceil((time_end - time) / dt);  // Number of time steps with this length
+		nsteps += ns;
+		time += ns * dt;
+
+		for (int i = 0; i < ns; i++)
+			dt_array.push_back(dt);
+		
+		if (time > horizon)
+		{
+			dt_array[nsteps - 1] -= (time - horizon);
+			break;
+		}
+	}
+
+	m_nstep_opt = (int) dt_array.size();
+
+	t_elapsed.resize(m_nstep_opt);
+	t_elapsed.at(0) = dt_array.at(0);
+	for (int j = 1; j < m_nstep_opt; j++)
+		t_elapsed.at(j) = t_elapsed.at(j - 1) + dt_array.at(j);
+
+	
+	t_weight.resize(m_nstep_opt);
+	for (int j = 0; j < m_nstep_opt; j++)
+		t_weight.at(j) = pow(params.disp_time_weighting, t_elapsed.at(j));
+
+	return true;
+}
+
+
+bool csp_dispatch_opt::translate_to_dispatch_timesteps(double wfstep, std::vector<double>& data)
+{
+	// Adjust time-resolution of data from constant time steps (wfstep in hr) to specified dispatch optimization time resolution
+	// Assumes all dispatch time steps are an integer multiple of the weather file time step
+
+	size_t n = dt_array.size();  // number of dispatch time steps
+	std::vector<double> newdata(n, 0.0);
+	int step_start = 0;
+	int wfstep_sec = (int)ceil(wfstep*3600. - 0.001);  // weather file time step in seconds
+
+	for (size_t j = 0; j < n; j++)
+	{
+		int dt_sec = (int)ceil(dt_array.at(j)*3600. - 0.001);  // Dispatch time step [s]
+		int divs_per_dt = dt_sec / wfstep_sec;					// Number of weather-file time steps in this dispatch time step
+		double ave_weight = 1. / (double)divs_per_dt;
+		
+		for (int i = 0; i < divs_per_dt; i++)
+			newdata.at(j) += data.at(step_start + i) * ave_weight;
+		step_start += divs_per_dt;
+	}
+	data = newdata;
+	return true;
+}
+
+bool csp_dispatch_opt::translate_to_dispatch_timesteps(double wfstep, util::matrix_t<double>& data)
+{
+	// Adjust time-resolution of data from constant time steps (wfstep in hr) to specified dispatch optimization time resolution
+	// Assumes all dispatch time steps are an integer multiple of the weather file time step
+
+	size_t n = dt_array.size();  // number of dispatch time steps
+	size_t nc = data.ncols();
+	size_t nr = data.nrows();
+	util::matrix_t<double> newdata(n, nc, 0.0);
+	int step_start = 0;
+	int wfstep_sec = (int)ceil(wfstep*3600. - 0.001);  // weather file time step in seconds
+
+	for (size_t j = 0; j < n; j++)
+	{
+		int dt_sec = (int)ceil(dt_array.at(j)*3600. - 0.001);  // Dispatch time step [s]
+		int divs_per_dt = dt_sec / wfstep_sec;					// Number of weather-file time steps in this dispatch time step
+		double ave_weight = 1. / (double)divs_per_dt;
+		
+		for (size_t c = 0; c < nc; c++)
+		{ 
+			for (int i = 0; i < divs_per_dt; i++)
+				newdata.at(j, c) += data.at(step_start + i, c) * ave_weight;
+		}
+		step_start += divs_per_dt;
+	}
+	data = newdata;
+	return true;
+}
+
+template <typename T>
+bool csp_dispatch_opt::translate_from_dispatch_timesteps(double wfstep, std::vector<T>& data)
+{
+	// Adjust time-resolution of data from dispatch time-step resolution to constant weather-file time step for use in ssc
+	// Assumes all dispatch time steps are an integer multiple of the weather file time step
+
+	int n_dispatch = (int)dt_array.size();		// Number of dispatch time steps
+
+	if (data.size() != n_dispatch)
+		return false;
+
+	int horizon = (int)ceil(t_elapsed.back() * 3600. - 0.001);	// Full dispatch time horizon (s)
+	int wfstep_sec = (int)ceil(wfstep*3600. - 0.001);		    // Weather file time step in seconds
+	int n_wf = horizon / wfstep_sec;							// Number of time steps in dispatch horizon at weather-file time resolution	
+	
+	std::vector<T> newdata(n_wf, 0.0);
+	int step_start = 0;
+	for (int j = 0; j < n_dispatch; j++)
+	{
+		int dt_sec = (int)ceil(dt_array.at(j)*3600. - 0.001);   // Dispatch time step [s]
+		int divs_per_dt = dt_sec / wfstep_sec;					// Number of weather-file time steps in this dispatch time step
+		for (int i = 0; i < divs_per_dt; i++)
+			newdata.at(step_start + i) = data.at(j);
+		step_start += divs_per_dt;
+	}
+	data = newdata;
+	return true;
+
+}
+
+bool csp_dispatch_opt::convert_outputs_to_weatherfile_timesteps(double wfstep)
+{
+	translate_from_dispatch_timesteps(wfstep, outputs.pb_standby);
+	translate_from_dispatch_timesteps(wfstep, outputs.pb_operation);
+	translate_from_dispatch_timesteps(wfstep, outputs.q_pb_standby);
+	translate_from_dispatch_timesteps(wfstep, outputs.q_pb_target);
+	translate_from_dispatch_timesteps(wfstep, outputs.rec_operation);
+	translate_from_dispatch_timesteps(wfstep, outputs.q_sf_expected);
+	translate_from_dispatch_timesteps(wfstep, outputs.tes_charge_expected);
+	translate_from_dispatch_timesteps(wfstep, outputs.q_pb_startup);
+	translate_from_dispatch_timesteps(wfstep, outputs.q_rec_startup);
+	translate_from_dispatch_timesteps(wfstep, outputs.w_pb_target);
+	return true;
+}
+
+
+
+bool csp_dispatch_opt::predict_performance(int step_start, double horizon, double wfstep)
 {
     //Step number - 1-based index for first hour of the year.
 
     //save step count
-    m_nstep_opt = ntimeints;
+	m_nstep_opt = dt_array.size();   // Number of time steps in dispatch optimization
+	int nstep_wf =  (int)(horizon / wfstep);  // Number of time steps in optimization horizon at weather-file resolution
 
     //Predict performance out nstep values. 
     clear_output_arrays();
@@ -292,16 +439,14 @@ bool csp_dispatch_opt::predict_performance(int step_start, int ntimeints, int di
 
     double Asf = params.col_rec->get_collector_area();
 
-    double ave_weight = 1./(double)divs_per_int;
-
     //resize the arrays
     int ns = forecast_params.is_stochastic ? forecast_params.n_scenarios : 1;
-    outputs.eta_sf_expected.resize(m_nstep_opt, ns );
-    outputs.q_sfavail_expected.resize(m_nstep_opt, ns );
-    outputs.eta_pb_expected.resize(m_nstep_opt, ns );
-    outputs.w_condf_expected.resize(m_nstep_opt, ns );
-	outputs.w_condf_expected.resize(m_nstep_opt, ns);
-	outputs.f_pb_op_limit.resize(m_nstep_opt, ns);
+    outputs.eta_sf_expected.resize(nstep_wf, ns );
+    outputs.q_sfavail_expected.resize(nstep_wf, ns );
+    outputs.eta_pb_expected.resize(nstep_wf, ns );
+    outputs.w_condf_expected.resize(nstep_wf, ns );
+	outputs.w_condf_expected.resize(nstep_wf, ns);
+	outputs.f_pb_op_limit.resize(nstep_wf, ns);
 
     C_csp_weatherreader::S_outputs *weatherstep;
     if( forecast_params.is_stochastic )
@@ -309,100 +454,87 @@ bool csp_dispatch_opt::predict_performance(int step_start, int ntimeints, int di
 
     for(int w=0; w<ns; w++)
     {
-        for(int t=0; t<m_nstep_opt; t++)
-        {
-        //initialize hourly average values
-        double therm_eff_ave = 0.;
-        double cycle_eff_ave = 0.;
-        double q_inc_ave = 0.;
-        double wcond_ave = 0.;
-		double f_pb_op_lim_ave = 0.0;
-
-        for(int j=0; j<divs_per_int; j++)     //take averages over hour if needed
+        for(int t=0; t<nstep_wf; t++)
         {
 
             //jump to the current step
-                if(! m_weather->read_time_step( step_start+t*divs_per_int+j, simloc ) )
+            if(! m_weather->read_time_step( step_start+t, simloc ) )
                 return false;
 
-                //if stochastic is used, adjust conditions for the scenario 's'
-                if( forecast_params.is_stochastic )
-                {
-                    *weatherstep = m_weather->ms_outputs;    //copy
+            //if stochastic is used, adjust conditions for the scenario 's'
+            if( forecast_params.is_stochastic )
+            {
+                *weatherstep = m_weather->ms_outputs;    //copy
 
-                    if( forecast_params.is_dni_scenarios )
-                        //if DNI is stochastic, assign the current DNI (beam) to be the value provided in the scenarios table
-                        weatherstep->m_beam = forecast_outputs.dni_scenarios.at(t, w);
-                    else
-                        //if no stochastic data was provided, copy over the actual from the weather file here. Don't reassign the value in the weatherstep object.
-                        forecast_outputs.dni_scenarios.at(t, w) = weatherstep->m_beam;  
-
-                    if( forecast_params.is_tdry_scenarios )
-                        //if tdry is stochastic, assign the current tdry to be the value provided in the scenarios table
-                        weatherstep->m_tdry = forecast_outputs.tdry_scenarios.at(t, w);
-                    else
-                        //if no stochastic data was provided, copy over the actual from the weather file here. Don't reassign the value in the weatherstep object.
-                        forecast_outputs.tdry_scenarios.at(t, w) = weatherstep->m_tdry;  
-
-                }
+                if( forecast_params.is_dni_scenarios )
+                    //if DNI is stochastic, assign the current DNI (beam) to be the value provided in the scenarios table
+                    weatherstep->m_beam = forecast_outputs.dni_scenarios.at(t, w);
                 else
-                {
-                    weatherstep = &m_weather->ms_outputs;   //point to
-                }
+                    //if no stochastic data was provided, copy over the actual from the weather file here. Don't reassign the value in the weatherstep object.
+                    forecast_outputs.dni_scenarios.at(t, w) = weatherstep->m_beam;  
+
+                if( forecast_params.is_tdry_scenarios )
+                    //if tdry is stochastic, assign the current tdry to be the value provided in the scenarios table
+                    weatherstep->m_tdry = forecast_outputs.tdry_scenarios.at(t, w);
+                else
+                    //if no stochastic data was provided, copy over the actual from the weather file here. Don't reassign the value in the weatherstep object.
+                    forecast_outputs.tdry_scenarios.at(t, w) = weatherstep->m_tdry;  
+
+            }
+            else
+            {
+                weatherstep = &m_weather->ms_outputs;   //point to
+            }
 
 
             //get DNI
-                //double dni = m_weather->ms_outputs.m_beam;
-				double dni = weatherstep->m_beam;
+			double dni = weatherstep->m_beam;
 
-                if( m_weather->ms_outputs.m_solzen > 90. || dni < 0. )
+            if( m_weather->ms_outputs.m_solzen > 90. || dni < 0. )
                 dni = 0.;
 
             //get optical efficiency
-                double opt_eff = params.col_rec->calculate_optical_efficiency(*weatherstep, simloc);
+            double opt_eff = params.col_rec->calculate_optical_efficiency(*weatherstep, simloc);
 
             double q_inc = Asf * opt_eff * dni * 1.e-3; //kW
 
             //get thermal efficiency
-                double therm_eff = params.col_rec->calculate_thermal_efficiency_approx(*weatherstep, q_inc*0.001);
-            therm_eff *= params.sf_effadj;
-            therm_eff_ave += therm_eff * ave_weight;
+            double therm_eff = params.col_rec->calculate_thermal_efficiency_approx(*weatherstep, q_inc*0.001);
+			therm_eff *= params.sf_effadj;
 
-            //store the predicted field energy output
-            q_inc_ave += q_inc * therm_eff * ave_weight;
 
             //store the power cycle efficiency
-                double cycle_eff = params.eff_table_Tdb.interpolate( weatherstep->m_tdry );
+            double cycle_eff = params.eff_table_Tdb.interpolate( weatherstep->m_tdry );
             cycle_eff *= params.eta_cycle_ref;  
-            cycle_eff_ave += cycle_eff * ave_weight;
 
 			double f_pb_op_lim_local = std::numeric_limits<double>::quiet_NaN();
 			double m_dot_htf_max_local = std::numeric_limits<double>::quiet_NaN();
 			params.mpc_pc->get_max_power_output_operation_constraints(weatherstep->m_tdry, m_dot_htf_max_local, f_pb_op_lim_local);
-			f_pb_op_lim_ave += f_pb_op_lim_local * ave_weight;	//[-]
+
 
             //store the condenser parasitic power fraction
-                double wcond_f = params.wcondcoef_table_Tdb.interpolate( weatherstep->m_tdry );
-            wcond_ave += wcond_f * ave_weight;
+            double wcond_f = params.wcondcoef_table_Tdb.interpolate( weatherstep->m_tdry );
 
 		    simloc.ms_ts.m_time += simloc.ms_ts.m_step;
-                m_weather->converged();
+            m_weather->converged();
+
+			// update arrays at weather-file resolution
+			outputs.eta_sf_expected.at(t, w) = therm_eff;			  // thermal efficiency
+			outputs.q_sfavail_expected.at(t, w) = q_inc * therm_eff;  // predicted field energy output
+			outputs.eta_pb_expected.at(t, w) = cycle_eff;			  // power cycle efficiency
+			outputs.f_pb_op_limit.at(t, w) = f_pb_op_lim_local;		  // maximum power cycle output (normalized)
+			outputs.w_condf_expected.at(t, w) = wcond_f;			   //condenser power
+
         }
 
-        //-----report hourly averages
-        //thermal efficiency
-            outputs.eta_sf_expected.at(t,w) = therm_eff_ave;
-        //predicted field energy output
-            outputs.q_sfavail_expected.at(t,w) = q_inc_ave;
-        //power cycle efficiency
-            outputs.eta_pb_expected.at(t,w) = cycle_eff_ave;
-		// Maximum power cycle output (normalized)
-			outputs.f_pb_op_limit.at(t, w) = f_pb_op_lim_ave;		//[-]
-        //condenser power
-            outputs.w_condf_expected.at(t,w) = wcond_ave;
     }
 
-    }
+	// convert arrays to dispatch time resolution
+	translate_to_dispatch_timesteps(wfstep, outputs.eta_sf_expected);
+	translate_to_dispatch_timesteps(wfstep, outputs.q_sfavail_expected);
+	translate_to_dispatch_timesteps(wfstep, outputs.eta_pb_expected);
+	translate_to_dispatch_timesteps(wfstep, outputs.f_pb_op_limit);
+	translate_to_dispatch_timesteps(wfstep, outputs.w_condf_expected);
 
     //reset the weather data reader
     //m_weather->jump_to_timestep(step_start, simloc);
@@ -421,22 +553,27 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
     */
 
         pars["T"] = nt ;
-        pars["delta"] = optinst->params.dt;
-        pars["Eu"] = optinst->params.e_tes_max ;
+
+		if (optinst->params.is_uniform_dt)
+		{
+			pars["delta"] = optinst->params.dt;
+		}
+        
+		pars["Eu"] = optinst->params.e_tes_max ;
         pars["Er"] = optinst->params.e_rec_startup ;
         pars["Ec"] = optinst->params.e_pb_startup_cold ;
         pars["Qu"] = optinst->params.q_pb_max ;
         pars["Ql"] = optinst->params.q_pb_min ;
         pars["Qru"] = optinst->params.e_rec_startup / optinst->params.dt_rec_startup;
         pars["Qrl"] = optinst->params.q_rec_min ;
-        pars["Qc"] = optinst->params.e_pb_startup_cold / ceil(optinst->params.dt_pb_startup_cold/pars["delta"]) / pars["delta"];
+
         pars["Qb"] = optinst->params.q_pb_standby ;
         pars["Lr"] = optinst->params.w_rec_pump ;
         pars["Lc"] = optinst->params.w_cycle_pump;
         pars["Wh"] = optinst->params.w_track;
         pars["Wb"] = optinst->params.w_cycle_standby;
         pars["Ehs"] = optinst->params.w_stow;
-        pars["Wrsb"] = optinst->params.w_rec_ht;
+        pars["Wht"] = optinst->params.w_rec_ht;
         pars["eta_cycle"] = optinst->params.eta_cycle_ref;
         pars["Qrsd"] = 0.;      //<< not yet modeled, passing temporarily as zero
 
@@ -448,7 +585,16 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
         pars["ycsb0"] = (optinst->params.is_pb_standby0 ? 1 : 0) ;
         pars["q0"] =  optinst->params.q_pb0 ;
         pars["Wdot0"] = optinst->params.w_pb0;
-        pars["qrecmaxobs"] = 1.;
+        
+		pars["yr0"] = (optinst->params.is_rec_operating0 ? 1 : 0);
+		pars["yrsb0"] = 0;
+		pars["yrsu0"] = 0;
+		pars["ycsu0"] = 0; 
+		
+		pars["deltal"] = optinst->params.dt_rec_startup;
+		
+		
+		pars["qrecmaxobs"] = 1.;
         for(int i=0; i<(int)optinst->outputs.q_sfavail_expected.nrows(); i++)
             pars["qrecmaxobs"] = optinst->outputs.q_sfavail_expected.at(i,0) > pars["qrecmaxobs"] ? optinst->outputs.q_sfavail_expected.at(i,0) : pars["qrecmaxobs"];
 
@@ -517,25 +663,28 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
         optinst->outputs.delta_rs.resize(nt, ns);
         for(int s=0; s<ns; s++)
         {
-        for(int t=0; t<nt; t++)
-        {
+			for(int t=0; t<nt; t++)
+			{
+				double tstep = optinst->dt_array.at(t);
+
 		        double wmin = (pars["Ql"] * pars["etap"]*optinst->outputs.eta_pb_expected.at(t,s) / optinst->params.eta_cycle_ref) + 
                                 (pars["Wdotu"] - pars["etap"]*pars["Qu"])*optinst->outputs.eta_pb_expected.at(t,s) / optinst->params.eta_cycle_ref; // Electricity generation at minimum pb thermal input
-		    double max_parasitic = 
-                        pars["Lr"] * optinst->outputs.q_sfavail_expected.at(t,s) 
-                + (optinst->params.w_rec_ht / optinst->params.dt) 
-                + (optinst->params.w_stow / optinst->params.dt) 
-                + optinst->params.w_track 
-                + optinst->params.w_cycle_standby 
-                + optinst->params.w_cycle_pump*pars["Qu"]
-                    + optinst->outputs.w_condf_expected.at(t,s)*pars["W_dot_cycle"];  // Largest possible parasitic load at time t
+				double max_parasitic = 
+					pars["Lr"] * optinst->outputs.q_sfavail_expected.at(t,s) 
+					+ (optinst->params.w_rec_ht / tstep)
+					+ (optinst->params.w_stow / tstep)
+					+ optinst->params.w_track 
+					+ optinst->params.w_cycle_standby 
+					+ optinst->params.w_cycle_pump*pars["Qu"]
+						+ optinst->outputs.w_condf_expected.at(t,s)*pars["W_dot_cycle"];  // Largest possible parasitic load at time t
 
-            //save for writing to ampl
+				//save for writing to ampl
                 optinst->outputs.wnet_lim_min.at(t, s) =  wmin - max_parasitic;
-            if( t < nt-1 )
-            {
-                    double delta_rec_startup = std::fmin(1., std::fmax(optinst->params.e_rec_startup / std::fmax(optinst->outputs.q_sfavail_expected.at(t + 1, s)*pars["delta"], 1.), optinst->params.dt_rec_startup / pars["delta"]));
-                    optinst->outputs.delta_rs.at(t, s) = delta_rec_startup;
+				if( t < nt-1 )
+				{
+					double tstep_next = optinst->dt_array.at(t + 1);
+					double delta_rec_startup = std::fmin(1., std::fmax(optinst->params.e_rec_startup / std::fmax(optinst->outputs.q_sfavail_expected.at(t + 1, s)*tstep_next, 1.), optinst->params.dt_rec_startup / tstep_next));
+					optinst->outputs.delta_rs.at(t, s) = delta_rec_startup;
                 }
             }
         }
@@ -546,103 +695,99 @@ static void calculate_parameters(csp_dispatch_opt *optinst, unordered_map<std::s
         pars["csu_cost"] = optinst->params.csu_cost; //10000.;
         pars["pen_delta_w"] = optinst->params.pen_delta_w; //0.1;
 
-		// time-dependent startup energy (only differs between time steps if user-defined fractional available capacity is a function of time)
+
+
+		// Allowable startup energy per period
 		optinst->outputs.Qc.resize(nt);
 		for (int t = 0; t < nt; t++)
-			optinst->outputs.Qc.at(t) = std::fmin(pars["Qc"], optinst->cap_frac.at(t) * optinst->params.q_pb_des);
+		{
+			if (optinst->params.is_uniform_dt)
+			{
+				pars["Qc"] = optinst->params.e_pb_startup_cold / ceil(optinst->params.dt_pb_startup_cold / pars["delta"]) / pars["delta"];
+				optinst->outputs.Qc.at(t) = std::fmin(pars["Qc"], optinst->cap_frac.at(t) * optinst->params.q_pb_des);
+			}
+			else
+			{
+				optinst->outputs.Qc.at(t) = optinst->params.e_pb_startup_cold / ceil(optinst->params.dt_pb_startup_cold / optinst->dt_array.at(t)) / optinst->dt_array.at(t);
+				optinst->outputs.Qc.at(t) = std::fmin(optinst->outputs.Qc.at(t), optinst->cap_frac.at(t) * optinst->params.q_pb_des);
+			}
+		}
 
-		
 
 
-		
 		//--- Cycle ramp rates 
-		pars["Qup"] = optinst->params.pb_max_rampup;
-		pars["Qdown"] = optinst->params.pb_max_rampdown;
+		pars["max_up"] = optinst->params.pb_max_rampup;     // Max allowable ramp-up rate (fraction of capacity per hour)
+		pars["max_down"] = optinst->params.pb_max_rampdown; // Max allowable ramp-down rate (fraction of capacity per hour)
 
-		pars["Qup_incr_su"] = std::fmax(0., 1.001*pars["Ql"] - pars["Qup"]);      // Allowable increase in max ramp-up at startup (only > 0 if max ramp-up < min operational level) 
-		pars["Qdown_incr_sd"] = std::fmax(0., 1.001*pars["Ql"] - pars["Qdown"]);  // Allowable increase in max ramp-down at shutdown (only > 0 if max ramp-down < min operational level) 
+		pars["max_up_v"] = optinst->params.pb_rampup_violation_lim;     // Maximum allowable violation of cycle ramp-up constraint (fraction of capacity per hour)
+		pars["max_down_v"] = optinst->params.pb_rampdown_violation_lim;  // Maximum allowable violation of cycle ramp-down constraint (fraction of capacity per hour)
 
-		// Relax ramp-down again if cycle cannot ramp down from initial state fast enough to turn off (occurs occasionally because of discrepancies in dispatch/solver solutions)
-		if (pars["Qdown_incr_sd"] > 0.0 && pars["q0"] > 0.0)
-		{
-			double s = pars["s0"];
-			double q = pars["q0"];
-			double qallow = pars["Qdown"] + pars["Qdown_incr_sd"];
-			int j = 0;
-			while (j < nt && q>qallow)
-			{
-				q -= pars["Qdown"];	
-				s -= q * pars["delta"];
-				s += optinst->outputs.q_sfavail_expected.at(j, 0) * pars["delta"];  
-				if (q > qallow && s < pars["delta"] * pars["Ql"])  // Cycle can't be shut off yet, but also can't be on or in standby during the next time step
-				{
-					pars["Qdown_incr_sd"] = 1.001*q - pars["Qdown"];
-					break;
-				}
-				j++;
-			}
-		}
+												
+		//--- Cycle min up/down time
+		pars["Yu"] = optinst->params.pb_minup;		 // Minimum up time [hr]
+		pars["Yd"] = optinst->params.pb_mindown;  // Minimum down time [hr]
+
+		pars["tup0"] = (optinst->params.is_pb_operating0) ? optinst->params.pb_persist0 : 0;   // Time up entering this horizon [hr]
+		pars["tstby0"] = (optinst->params.is_pb_standby0) ? optinst->params.pb_persist0 : 0;   // Time in standby entering this horizon [hr]
+		pars["tdown0"] = (!optinst->params.is_pb_operating0 && !optinst->params.is_pb_standby0) ? optinst->params.pb_persist0 : 0; // Time down entering this horizon [hr]
 
 
-		// Cycle min up/down time
-		pars["Nup"] = optinst->params.pb_minup;
-		pars["Ndown"] = optinst->params.pb_mindown;
-
-		pars["Nup0"] = (optinst->params.is_pb_operating0) ? optinst->params.pb_persist0 : 0;
-		pars["Nstby0"] = (optinst->params.is_pb_standby0) ? optinst->params.pb_persist0 : 0;
-		pars["Ndown0"] = (!optinst->params.is_pb_operating0 && !optinst->params.is_pb_standby0) ? optinst->params.pb_persist0 : 0;
 
 		
-		// Decision permanence
-		pars["P_onoff"] = optinst->perm.pb_onoff;
-		pars["P_onoff_lookahead"] = optinst->perm.pb_onoff_lookahead;
-
-		pars["P_level"] = optinst->perm.pb_level;
-		pars["P_level_lookahead"] = optinst->perm.pb_level_lookahead;
-		
-		pars["P_onoff_rec"] = optinst->perm.rec_onoff;
-		pars["P_onoff_rec_lookahead"] = optinst->perm.rec_onoff_lookahead;
-
-
-
-		// Storage buffer
-		optinst->outputs.s_min.resize(nt, ns);
-		optinst->outputs.s_min.fill(optinst->params.e_tes_buffer);
-		if (pars["s0"] < optinst->params.e_tes_buffer)  // Initial storage capacity is below allowable value -> relax constraint until receiver energy is available to make up the difference
+		// Parameters not used in ampl
+		if (!optinst->solver_params.is_ampl_engine)
 		{
-			for (int s = 0; s < ns; s++)
+			//--- Decision permanence [hr]
+			pars["P_onoff"] = optinst->perm.pb_onoff;
+			pars["P_onoff_lookahead"] = optinst->perm.pb_onoff_lookahead;
+
+			pars["P_level"] = optinst->perm.pb_level;
+			pars["P_level_lookahead"] = optinst->perm.pb_level_lookahead;
+
+			pars["P_onoff_rec"] = optinst->perm.rec_onoff;
+			pars["P_onoff_rec_lookahead"] = optinst->perm.rec_onoff_lookahead;
+
+
+			//--- Storage buffer
+			optinst->outputs.s_min.resize(nt, ns);
+			optinst->outputs.s_min.fill(optinst->params.e_tes_buffer);
+			if (pars["s0"] < optinst->params.e_tes_buffer)  // Initial storage capacity is below allowable value -> relax constraint until receiver energy is available to make up the difference
 			{
-				double rec_accum = 0.0;
-				double startup_require = optinst->params.e_rec_startup;
-				if (optinst->params.is_rec_operating0)
-					startup_require = 0.0;
-
-				for (int t = 0; t < nt; t++)
+				for (int s = 0; s < ns; s++)
 				{
+					double rec_accum = 0.0;
+					double startup_require = optinst->params.e_rec_startup;
+					if (optinst->params.is_rec_operating0)
+						startup_require = 0.0;
 
-					if (startup_require > 0.0)
+					for (int t = 0; t < nt; t++)
 					{
-						if (optinst->outputs.q_sfavail_expected.at(t, s) < pars["Qru"])
-							startup_require = optinst->params.e_rec_startup;
-						else
-							startup_require -= pars["Qru"] * pars["delta"];
-					}
 
-					else
-					{
-						if (optinst->outputs.q_sfavail_expected.at(t, s) < pars["Qrl"])
-							startup_require = optinst->params.e_rec_startup;
-						else
-							rec_accum += optinst->outputs.q_sfavail_expected.at(t, s) * pars["delta"];  // Available accumulated energy from receiver [kWht]
-					}
+						if (startup_require > 0.0)
+						{
+							if (optinst->outputs.q_sfavail_expected.at(t, s) < pars["Qru"])
+								startup_require = optinst->params.e_rec_startup;
+							else
+								startup_require -= pars["Qru"] * pars["delta"];
+						}
 
-					if (rec_accum < (optinst->params.e_tes_buffer - pars["s0"]))			// Cumulative receiver energy is insufficient to increase storage above allowable min
-						optinst->outputs.s_min.at(t, s) = optinst->params.e_tes_init;		// Relax storage lower bound to initial storage availability
-					else
-						break;
+						else
+						{
+							if (optinst->outputs.q_sfavail_expected.at(t, s) < pars["Qrl"])
+								startup_require = optinst->params.e_rec_startup;
+							else
+								rec_accum += optinst->outputs.q_sfavail_expected.at(t, s) * pars["delta"];  // Available accumulated energy from receiver [kWht]
+						}
+
+						if (rec_accum < (optinst->params.e_tes_buffer - pars["s0"]))			// Cumulative receiver energy is insufficient to increase storage above allowable min
+							optinst->outputs.s_min.at(t, s) = optinst->params.e_tes_init;		// Relax storage lower bound to initial storage availability
+						else
+							break;
+					}
 				}
 			}
 		}
+
 
 
 };
@@ -655,6 +800,13 @@ bool csp_dispatch_opt::optimize()
     {
         return optimize_ampl();
     }
+	
+	// Skip optimization if non-uniform time steps are specified
+	if (!params.is_uniform_dt)
+	{
+		return false;
+	}
+
 
     /* 
     Formulate the optimization problem for dispatch generation. We are trying to maximize revenue subject to inventory
@@ -1446,6 +1598,33 @@ bool csp_dispatch_opt::optimize()
 			REAL row[5];
 			int col[5];
 
+
+			// Convert ramp rate from fraction of capacity per hour to allowable thermal energy per time step
+			double Qup = P["max_up"] * P["Qu"] / P["delta"];			  // Maximum increase in thermal energy to the cycle per time step [kWt]
+			double Qdown = P["max_down"] * P["Qu"] / P["delta"];		  // Maximum decrease in thermal energy to the cycle per time step [kWt]
+			double Qup_incr_su = std::fmax(0., 1.001*P["Ql"] - Qup);      // Allowable increase in max ramp-up at startup (only > 0 if max ramp-up < min operational level) 
+			double Qdown_incr_sd = std::fmax(0., 1.001*P["Ql"] - Qdown);  // Allowable increase in max ramp-down at shutdown (only > 0 if max ramp-down < min operational level) 			
+			if (Qdown_incr_sd > 0.0 && P["q0"] > 0.0) // Relax ramp-down again if cycle cannot ramp down from initial state fast enough to turn off (occurs occasionally because of discrepancies in dispatch/solver solutions)
+			{
+				double s = P["s0"];
+				double q = P["q0"];
+				double qallow = Qdown + Qdown_incr_sd;
+				int j = 0;
+				while (j < nt && q>qallow)
+				{
+					q -= Qdown;
+					s -= q * P["delta"];
+					s += outputs.q_sfavail_expected.at(j, 0) * P["delta"];
+					if (q > qallow && s < P["delta"] * P["Ql"])  // Cycle can't be shut off yet, but also can't be on or in standby during the next time step
+					{
+						Qdown_incr_sd = 1.001*q - Qdown;
+						break;
+					}
+					j++;
+				}
+			}
+
+
 			for (int t = 0; t < nt; t++)
 			{
 				//--- Max cycle ramp-up 
@@ -1456,17 +1635,17 @@ bool csp_dispatch_opt::optimize()
 					row[1] = -1.;
 					col[1] = O.column("x", t - 1);
 
-					row[2] = P["Qup_incr_su"];
+					row[2] = Qup_incr_su;
 					col[2] = O.column("y", t - 1);
 
-					row[3] = P["Qup_incr_su"];
+					row[3] = Qup_incr_su;
 					col[3] = O.column("ycsb", t - 1);
 
-					add_constraintex(lp, 4, row, col, LE, P["Qup"] + P["Qup_incr_su"]);
+					add_constraintex(lp, 4, row, col, LE, Qup + Qup_incr_su);
 				}
 				else
 				{
-					double RHS = P["q0"] + P["Qup"] + (1.0 - P["y0"] - P["ycsb0"]) * P["Qup_incr_su"];
+					double RHS = P["q0"] + Qup + (1.0 - P["y0"] - P["ycsb0"]) * Qup_incr_su;
 					add_constraintex(lp, 1, row, col, LE, RHS);
 				}
 
@@ -1475,10 +1654,10 @@ bool csp_dispatch_opt::optimize()
 				row[0] = 1.;
 				col[0] = O.column("x", t);
 
-				row[1] = -P["Qdown_incr_sd"];
+				row[1] = -Qdown_incr_sd;
 				col[1] = O.column("y", t);
 
-				row[2] = -P["Qdown_incr_sd"];
+				row[2] = -Qdown_incr_sd;
 				col[2] = O.column("ycsb", t);
 
 				if (t > 0)
@@ -1486,15 +1665,15 @@ bool csp_dispatch_opt::optimize()
 					row[3] = -1.;
 					col[3] = O.column("x", t - 1);
 
-					add_constraintex(lp, 4, row, col, GE, -P["Qdown"] - P["Qdown_incr_sd"]);
+					add_constraintex(lp, 4, row, col, GE, -Qdown - Qdown_incr_sd);
 				}
 				
 				else
 				{
-					add_constraintex(lp, 3, row, col, GE, P["q0"] - P["Qdown"] - P["Qdown_incr_sd"]);
+					add_constraintex(lp, 3, row, col, GE, P["q0"] - Qdown - Qdown_incr_sd);
 					//double max_avail = P["s0"] / P["delta"] + outputs.q_sfavail_expected.at(t, 0); 
-					//if (P["q0"] <= P["Qdown"]+ P["Qdown_incr_sd"] || max_avail > std::fmax(P["Ql"], P["q0"]-P["Qdown"]))  // Ramp-down is feasible
-					//	add_constraintex(lp, 3, row, col, GE, P["q0"] - P["Qdown"] - P["Qdown_incr_sd"]);
+					//if (P["q0"] <= Qdown + Qdown_incr_sd || max_avail > std::fmax(P["Ql"], P["q0"]-Qdown))  // Ramp-down is feasible
+					//	add_constraintex(lp, 3, row, col, GE, P["q0"] - Qdown - Qdown_incr_sd);
 				}
 				
 			}
@@ -1512,10 +1691,12 @@ bool csp_dispatch_opt::optimize()
 			int col[24];
 
 			//--- Minimum up time
-			if (P["Nup"] > 1)
+			int Nup = (int)ceil(P["Yu"] / P["delta"]);  // minimum up time in number of time steps
+			int Nup0 = (int)ceil(P["tup0"] / P["delta"]);
+			if (Nup > 1)
 			{
-				int nforce = (P["y0"] == 1) ? (int)std::fmax(0, P["Nup"] - P["Nup0"]) : 0;	// Number of time steps at beginning of window that cyle has to be up
-				double fract = 1. / (float)P["Nup"];
+				int nforce = (P["y0"] == 1) ? (int)std::fmax(0, Nup - Nup0) : 0;	// Number of time steps at beginning of window that cyle has to be up
+				double fract = 1. / (float)Nup;
 
 				for (int t = 0; t < nt; t++)
 				{
@@ -1532,18 +1713,18 @@ bool csp_dispatch_opt::optimize()
 						row[i] = -1. + fract;
 						col[i++] = O.column("y", t - 1);
 
-						int k = (int)std::fmin(P["Nup"], t);  
+						int k = (int)std::fmin(Nup, t);  
 						for (int j = 2; j <= k; j++)
 						{
 							row[i] = fract;
 							col[i++] = O.column("y", t - j);
 						}
 
-						if (k == P["Nup"]) // Full minimum up-time window is in this optimization window
+						if (k == Nup) // Full minimum up-time window is in this optimization window
 							add_constraintex(lp, i, row, col, GE, 0.0);
 						else
 						{
-							int n_up_prev = (int)std::fmin(P["Nup"] - t, P["Nup0"]);  // Number of time steps in previous window that contribute
+							int n_up_prev = (int)std::fmin(Nup - t, Nup0);  // Number of time steps in previous window that contribute
 							add_constraintex(lp, i, row, col, GE, -fract * n_up_prev);
 						}
 					}
@@ -1551,10 +1732,12 @@ bool csp_dispatch_opt::optimize()
 			}
 
 			//--- Minimum down time
-			if (P["Ndown"] > 1)
+			int Ndown = (int)ceil(P["Yd"] / P["delta"]);
+			int Ndown0 = (int)ceil(P["tdown0"] / P["delta"]);
+			if (Ndown > 1)
 			{
-				int nforce = (P["y0"] == 0) ? (int)std::fmax(0, P["Ndown"] - P["Ndown0"]) : 0;	 // Number of time steps at beginning of window that cyle has to be down
-				double fract = 1. / (float)P["Ndown"];
+				int nforce = (P["y0"] == 0) ? (int)std::fmax(0, Ndown - Ndown0) : 0;	 // Number of time steps at beginning of window that cyle has to be down
+				double fract = 1. / (float)Ndown;
 
 				for (int t = 0; t < nt; t++)
 				{
@@ -1571,18 +1754,18 @@ bool csp_dispatch_opt::optimize()
 						row[i] = -1. + fract;
 						col[i++] = O.column("y", t - 1);
 
-						int k = (int)std::fmin(P["Ndown"], t);  
+						int k = (int)std::fmin(Ndown, t);  
 						for (int j = 2; j <= k; j++)
 						{
 							row[i] = fract;
 							col[i++] = O.column("y", t - j);
 						}
 
-						if (k == P["Ndown"]) // Full minimum down-time window is in this optimization window
+						if (k == Ndown) // Full minimum down-time window is in this optimization window
 							add_constraintex(lp, i, row, col, LE, 1.0);
 						else
 						{
-							int n_down_prev = (int)std::fmin(P["Ndown"] - t, P["Ndown0"]);  // Number of time steps in previous window that contribute
+							int n_down_prev = (int)std::fmin(Ndown - t, Ndown0);  // Number of time steps in previous window that contribute
 							add_constraintex(lp, i, row, col, LE, fract*(n_down_prev+t));
 						}
 					}
@@ -1772,13 +1955,21 @@ bool csp_dispatch_opt::optimize()
 
 			bool is_decision;
 
+			int np_onoff = (int)ceil(P["P_onoff"] / P["delta"]);
+			int np_level = (int)ceil(P["P_level"] / P["delta"]);
+			int np_onoff_rec = (int)ceil(P["P_onoff_rec"] / P["delta"]);
+
+			int np_onoff_lookahead = (int)ceil(P["P_onoff_lookahead"] / P["delta"]);
+			int np_level_lookahead = (int)ceil(P["P_level_lookahead"] / P["delta"]);
+			int np_onoff_rec_lookahead = (int)ceil(P["P_onoff_rec_lookahead"] / P["delta"]);
+
 			for (int t = 0; t < nt; t++)
 			{
 				// Cycle on/off/standby
 				is_decision = true;
-				if (t < nt - nt_lookahead && t % (int)P["P_onoff"] != 0)  // Optimization window
+				if (t < nt - nt_lookahead && t % np_onoff != 0)  // Optimization window
 					is_decision = false;
-				if (t >= nt - nt_lookahead && t % (int)P["P_onoff_lookahead"] != 0) // Lookahead period
+				if (t >= nt - nt_lookahead && t % np_onoff_lookahead != 0) // Lookahead period
 					is_decision = false;
 
 				if (!is_decision)  // Not allowed to change state in this step
@@ -1798,9 +1989,9 @@ bool csp_dispatch_opt::optimize()
 
 				// Cycle operational level permanance
 				is_decision = true;
-				if (t < nt - nt_lookahead && t % (int)P["P_level"] != 0)  // Optimization window
+				if (t < nt - nt_lookahead && t % np_level != 0)  // Optimization window
 					is_decision = false;
-				if (t >= nt - nt_lookahead && t % (int)P["P_level_lookahead"] != 0) // Lookahead period
+				if (t >= nt - nt_lookahead && t % np_level_lookahead != 0) // Lookahead period
 					is_decision = false;
 
 				if (!is_decision)  // Not allowed to change operational level
@@ -1815,9 +2006,9 @@ bool csp_dispatch_opt::optimize()
 
 				// Receiver on/off
 				is_decision = true;
-				if (t < nt - nt_lookahead && t % (int)P["P_onoff_rec"] != 0)  // Optimization window
+				if (t < nt - nt_lookahead && t % np_onoff_rec != 0)  // Optimization window
 					is_decision = false;
-				if (t >= nt - nt_lookahead && t % (int)P["P_onoff_rec_lookahead"] != 0) // Lookahead period
+				if (t >= nt - nt_lookahead && t % np_onoff_rec_lookahead != 0) // Lookahead period
 					is_decision = false;
 
 				if (!is_decision)
@@ -2323,9 +2514,6 @@ std::string csp_dispatch_opt::write_ampl()
         calculate_parameters(this, pars, nt);
 
 
-        //double dq_rsu = params.e_rec_startup / params.dt_rec_startup;
-        //double dq_csu = params.e_pb_startup_cold / ceil(params.dt_pb_startup_cold/params.dt) / params.dt;
-
         fout << "#data file\n\n";
         fout << "# --- scalar parameters ----\n";
         fout << "param day_of_year := " << day << ";\n";
@@ -2342,7 +2530,7 @@ std::string csp_dispatch_opt::write_ampl()
 
         fout << "# --- indexed parameters ---\n";
 
-        write_ampl_variable_array( fout, w_lim, "Wdotnet" ); //net power limit
+		write_ampl_variable_array( fout, w_lim, "Wdotnet" ); //net power limit
 
         if( forecast_params.is_stochastic )
         {
@@ -2365,6 +2553,15 @@ std::string csp_dispatch_opt::write_ampl()
 
 		write_ampl_variable_array(fout, cap_frac, "cap_frac");
 		write_ampl_variable_array(fout, eff_frac, "eff_frac");
+		write_ampl_variable_array(fout, outputs.Qc, "Qc");
+
+		if (!params.is_uniform_dt)
+		{
+			write_ampl_variable_array(fout, dt_array, "dt");   // Time-step durations [hr]
+			write_ampl_variable_array(fout, t_elapsed, "dte"); // Cumulative time elapsed [hr]
+			write_ampl_variable_array(fout, t_weight, "twt");  // Time weighting factor
+		}
+
 
         fout.close();
     }

--- a/tcs/csp_dispatch.cpp
+++ b/tcs/csp_dispatch.cpp
@@ -1102,41 +1102,41 @@ bool csp_dispatch_opt::optimize()
 
         
         // ******************** Power cycle constraints *******************
-        {
-            REAL row[5];
-            int col[5];
+		{
+			REAL row[5];
+			int col[5];
 
-            for(int t=0; t<nt; t++)
-            {
+			for (int t = 0; t < nt; t++)
+			{
 
-                int i=0;
-                //Startup Inventory balance
-                row[i  ] = 1.;
-                col[i++] = O.column("ucsu", t);
-                
+				int i = 0;
+				//Startup Inventory balance
+				row[i] = 1.;
+				col[i++] = O.column("ucsu", t);
+
 				row[i] = -P["delta"] * outputs.Qc.at(t); // -P["delta"] * P["Qc"];
-                col[i++] = O.column("ycsu", t);
+				col[i++] = O.column("ycsu", t);
 
-                if(t>0)
-                {
-                    row[i  ] = -1.;
-                    col[i++] = O.column("ucsu", t-1);
-                }
+				if (t > 0)
+				{
+					row[i] = -1.;
+					col[i++] = O.column("ucsu", t - 1);
+				}
 
-                add_constraintex(lp, i, row, col, LE, 0.);
+				add_constraintex(lp, i, row, col, LE, 0.);
 
-                //Inventory nonzero
-                row[0] = 1.;
-                col[0] = O.column("ucsu", t);
+				//Inventory nonzero
+				row[0] = 1.;
+				col[0] = O.column("ucsu", t);
 
-                row[1] = -P["M"];
-                col[1] = O.column("ycsu", t);
+				row[1] = -P["M"];
+				col[1] = O.column("ycsu", t);
 
-                add_constraintex(lp, 2, row, col, LE, 0.);
+				add_constraintex(lp, 2, row, col, LE, 0.);
 
 
 				// Original constraints: applied whenever cycle startup can be completed in a single time step and at least minimum operation can also occur in that timestep
-				if (P["delta"] * outputs.Qc.at(t) >= 0.999*P["Ec"] && outputs.Qc.at(t) + P["Ql"] < P["Qu"]*cap_frac.at(t))
+				if (P["delta"] * outputs.Qc.at(t) >= 0.999*P["Ec"] && outputs.Qc.at(t) + P["Ql"] < P["Qu"] * cap_frac.at(t))
 				{
 					//Cycle operation allowed when:
 					i = 0;
@@ -1175,9 +1175,9 @@ bool csp_dispatch_opt::optimize()
 					col[i++] = O.column("y", t);
 
 					add_constraintex(lp, i, row, col, LE, 0.);
-					
+
 				}
-				
+
 				// jm 10/2018: Modified constraints applied in cases when cycle startup requires multiple timesteps or full cycle startup and minimum operation can't occur in the same timestep
 				else
 				{
@@ -1211,28 +1211,28 @@ bool csp_dispatch_opt::optimize()
 					add_constraintex(lp, 2, row, col, LE, P["Qu"] * cap_frac.at(t));
 
 				}
-				
 
 
 
-                //cycle operation mode requirement
-                row[0] = 1.;
-                col[0] = O.column("x", t);
 
-                row[1] = -P["Qu"] * cap_frac.at(t);
-                col[1] = O.column("y", t);
+				//cycle operation mode requirement
+				row[0] = 1.;
+				col[0] = O.column("x", t);
 
-                add_constraintex(lp, 2, row, col, LE, 0.);
+				row[1] = -P["Qu"] * cap_frac.at(t);
+				col[1] = O.column("y", t);
 
-                //Minimum cycle energy contribution
-                i=0;
-                row[i  ] = 1.;
-                col[i++] = O.column("x", t);
+				add_constraintex(lp, 2, row, col, LE, 0.);
 
-                row[i  ] = -P["Ql"];
-                col[i++] = O.column("y", t);
+				//Minimum cycle energy contribution
+				i = 0;
+				row[i] = 1.;
+				col[i++] = O.column("x", t);
 
-                add_constraintex(lp, i, row, col, GE, 0);
+				row[i] = -P["Ql"];
+				col[i++] = O.column("y", t);
+
+				add_constraintex(lp, i, row, col, GE, 0);
 
 
 				// Cycle standby not allowed if constrained capacity less than standby requirement
@@ -1241,20 +1241,20 @@ bool csp_dispatch_opt::optimize()
 				add_constraintex(lp, 1, row, col, LE, P["Qu"] * cap_frac.at(t));
 
 
-                //cycle startup can't be enabled after a time step where the cycle was operating
-                if(t>0)
-                {
-                    row[0] = 1.;
-                    col[0] = O.column("ycsu", t);
+				//cycle startup can't be enabled after a time step where the cycle was operating
+				if (t > 0)
+				{
+					row[0] = 1.;
+					col[0] = O.column("ycsu", t);
 
-                    row[1] = 1.;
-                    col[1] = O.column("y", t-1);
+					row[1] = 1.;
+					col[1] = O.column("y", t - 1);
 
-                    add_constraintex(lp, 2, row, col, LE, 1.);
-                }
+					add_constraintex(lp, 2, row, col, LE, 1.);
+				}
 
 				//cycle startup can't be enabled after a time step where the cycle was in standby
-				if (t>0)
+				if (t > 0)
 				{
 					row[0] = 1.;
 					col[0] = O.column("ycsu", t);
@@ -1273,108 +1273,180 @@ bool csp_dispatch_opt::optimize()
 					add_constraintex(lp, 1, row, col, LE, std::fmin((params.is_pb_operating0 ? 0. : 1.), (params.is_pb_standby0 ? 0. : 1.)));
 				}
 
-                //Standby mode entry
-                i=0;
-                row[i  ] = 1.;
-                col[i++] = O.column("ycsb", t);
+				//Standby mode entry
+				i = 0;
+				row[i] = 1.;
+				col[i++] = O.column("ycsb", t);
 
-                if(t>0)
-                {
-                    row[i  ] = -1.;
-                    col[i++] = O.column("y", t-1);
-
-                    row[i  ] = -1.;
-                    col[i++] = O.column("ycsb", t-1);
-
-                    add_constraintex(lp, i, row, col, LE, 0);
-                }
-                else
-                {
-                    add_constraintex(lp, i, row, col, LE, (params.is_pb_standby0 ? 1 : 0) + (params.is_pb_operating0 ? 1 : 0));
-                }
-
-                //some modes can't coincide
-                row[0] = 1.;
-                col[0] = O.column("ycsu", t);
-                row[1] = 1.;
-                col[1] = O.column("ycsb", t);    
-
-                add_constraintex(lp, 2, row, col, LE, 1);   
-
-                row[0] = 1.;
-                col[0] = O.column("y", t);
-                row[1] = 1.;
-                col[1] = O.column("ycsb", t);    
-
-                add_constraintex(lp, 2, row, col, LE, 1);   
-
-                if( t > 0 )
-                {
-                    //cycle start penalty
-                    row[0] = 1.;
-                    col[0] = O.column("ycsup", t);
-
-                    row[1] = -1.;
-                    col[1] = O.column("ycsu", t);
-
-                    row[2] = 1.;
-                    col[2] = O.column("ycsu", t-1);
-
-                    add_constraintex(lp, 3, row, col, GE, 0.);
-
-                    //cycle standby start penalty
-                    row[0] = 1.;
-                    col[0] = O.column("ychsp", t);
-
-                    row[1] = -1.;
-                    col[1] = O.column("y", t);
-
-                    row[2] = -1.;
-                    col[2] = O.column("ycsb", t-1);
-
-                    add_constraintex(lp, 3, row, col, GE, -1.);
-
-#ifdef MOD_CYCLE_SHUTDOWN
-                    //cycle shutdown energy penalty
-                    row[0] = 1.;
-                    col[0] = O.column("ycsd", t-1);
-
-                    row[1] = -1.;
-                    col[1] = O.column("y", t-1);
-                    
-                    row[2] = 1.;
-                    col[2] = O.column("y", t);
-                    
-                    row[3] = -1.;
-                    col[3] = O.column("ycsb", t-1);
-                    
-                    row[4] = 1.;
-                    col[4] = O.column("ycsb", t);
-
-                    add_constraintex(lp, 5, row, col, GE, 0.);
-#endif
-
-                }
-
-				// Max cycle ramp-up and ramp-down
-				row[0] = 1.;
-                col[0] = O.column("x", t);
 				if (t > 0)
 				{
-					row[1] = -1.;
-					col[1] = O.column("x", t-1);
+					row[i] = -1.;
+					col[i++] = O.column("y", t - 1);
 
-					add_constraintex(lp, 2, row, col, LE, P["qpbmaxup"]);
-					add_constraintex(lp, 2, row, col, GE, -P["qpbmaxdown"]);
+					row[i] = -1.;
+					col[i++] = O.column("ycsb", t - 1);
+
+					add_constraintex(lp, i, row, col, LE, 0);
 				}
 				else
 				{
-					add_constraintex(lp, 2, row, col, LE, P["q0"] + P["qpbmaxup"]);
-					add_constraintex(lp, 2, row, col, GE, P["q0"] - P["qpbmaxdown"]);
+					add_constraintex(lp, i, row, col, LE, (params.is_pb_standby0 ? 1 : 0) + (params.is_pb_operating0 ? 1 : 0));
+				}
+
+				//some modes can't coincide
+				row[0] = 1.;
+				col[0] = O.column("ycsu", t);
+				row[1] = 1.;
+				col[1] = O.column("ycsb", t);
+
+				add_constraintex(lp, 2, row, col, LE, 1);
+
+				row[0] = 1.;
+				col[0] = O.column("y", t);
+				row[1] = 1.;
+				col[1] = O.column("ycsb", t);
+
+				add_constraintex(lp, 2, row, col, LE, 1);
+
+				if (t > 0)
+				{
+					//cycle start penalty
+					row[0] = 1.;
+					col[0] = O.column("ycsup", t);
+
+					row[1] = -1.;
+					col[1] = O.column("ycsu", t);
+
+					row[2] = 1.;
+					col[2] = O.column("ycsu", t - 1);
+
+					add_constraintex(lp, 3, row, col, GE, 0.);
+
+					//cycle standby start penalty
+					row[0] = 1.;
+					col[0] = O.column("ychsp", t);
+
+					row[1] = -1.;
+					col[1] = O.column("y", t);
+
+					row[2] = -1.;
+					col[2] = O.column("ycsb", t - 1);
+
+					add_constraintex(lp, 3, row, col, GE, -1.);
+
+#ifdef MOD_CYCLE_SHUTDOWN
+					//cycle shutdown energy penalty
+					row[0] = 1.;
+					col[0] = O.column("ycsd", t - 1);
+
+					row[1] = -1.;
+					col[1] = O.column("y", t - 1);
+
+					row[2] = 1.;
+					col[2] = O.column("y", t);
+
+					row[3] = -1.;
+					col[3] = O.column("ycsb", t - 1);
+
+					row[4] = 1.;
+					col[4] = O.column("ycsb", t);
+
+					add_constraintex(lp, 5, row, col, GE, 0.);
+#endif
+
+				}
+			}
+		}
+
+
+		// ******************** Cycle ramp-up and ramp-down rates *******************
+		{
+			REAL row[5];
+			int col[5];
+
+			//--- Max cycle ramp-up 
+			double increase_rampup = std::fmax(0., 1.001*P["Ql"] - P["qpbmaxup"]); // Allowable increase in max ramp-up at startup if max ramp-up < min operational level 
+			for (int t = 0; t < nt; t++)
+			{
+				row[0] = 1.;
+				col[0] = O.column("x", t);
+				if (t > 0)
+				{
+					row[1] = -1.;
+					col[1] = O.column("x", t - 1);
+
+					row[2] = increase_rampup;
+					col[2] = O.column("y", t - 1);
+
+					row[3] = increase_rampup;
+					col[3] = O.column("ycsb", t - 1);
+
+					add_constraintex(lp, 4, row, col, LE, P["qpbmaxup"] + increase_rampup);
+				}
+				else
+				{
+					double RHS = P["q0"] + P["qpbmaxup"] + (1.0 - P["y0"] - P["ycsb0"]) * increase_rampup;
+					add_constraintex(lp, 1, row, col, LE, RHS);
+				}
+			}
+
+
+
+			//--- Max cycle ramp-down
+
+			// Does ramp-down constraint at shutdown need to be relaxed to find a feasible solution?  
+			double increase_rampdown = std::fmax(0., 1.001*P["Ql"] - P["qpbmaxdown"]); // Allowable increase in max ramp-down at shutdown if max ramp-down < min operational level 
+			if (increase_rampdown > 0.0)  
+			{
+				// See if cycle can ramp down fast enough to shut off before storage runs out, and increase allowable ramp-down at shutoff if not (occurs occasionally because of discrepancies in dispatch/solver solutions)
+				double s = P["s0"];
+				double q = P["q0"];
+				double qallow = P["qpbmaxdown"] + increase_rampdown;  
+				int j = 0;
+				while (j < nt && q>qallow && outputs.q_sfavail_expected.at(j, 0) < 1.e-6)
+				{
+					q -= P["qpbmaxdown"];
+					s -= q * P["delta"];
+					if (q > qallow && s < P["delta"] * P["Ql"])  // Cycle can't be shut off yet, but also can't be on or in standby during the next time step
+					{
+						increase_rampdown = 1.001*q - P["qpbmaxdown"];				 
+						break;
+					}
+					j++;
+				}
+				//params.messages->add_message(C_csp_messages::NOTICE, util::format("Allowable ramp-down at shut-down set to %.2f", increase_rampdown));
+			}
+
+
+			for (int t = 0; t < nt; t++)
+			{
+
+				row[0] = 1.;
+                col[0] = O.column("x", t);
+
+				row[1] = -increase_rampdown;
+				col[1] = O.column("y", t);
+
+				row[2] = -increase_rampdown;
+				col[2] = O.column("ycsb", t);
+
+				if (t > 0)
+				{
+					row[3] = -1.;
+					col[3] = O.column("x", t-1);
+
+					add_constraintex(lp, 4, row, col, GE, -P["qpbmaxdown"] - increase_rampdown);
+				}
+				else
+				{
+					double max_avail = P["s0"] / P["delta"] + outputs.q_sfavail_expected.at(t, 0); 
+					if (P["q0"] <= P["qpbmaxdown"]+increase_rampdown || max_avail > P["Ql"])  // Ramp-down is feasible
+						add_constraintex(lp, 3, row, col, GE, P["q0"] - P["qpbmaxdown"] - increase_rampdown);
 				}
 
             }
         }
+
 
 		// ******************** Cycle min up- and down- times *******************
 		{

--- a/tcs/csp_dispatch.h
+++ b/tcs/csp_dispatch.h
@@ -127,10 +127,14 @@ public:
     struct s_params
     {
         bool is_rec_operating0;     //receiver is operating at the initial time step
+		bool is_rec_startup0;		//receiver is starting up at the initial time step
         bool is_pb_operating0;      //Power block is operating at the initial time step
         bool is_pb_standby0;        //Power block is in standby at the initial time step
+		bool is_pb_startup0;		//Power block is starting up at the initial time step
         double q_pb0;               //[kWt] Thermal power consumption in the cycle entering the initial time step
         double w_pb0;               //[kWe] Power production from the cycle entering the initial time step
+		double u_csu0;				//[kWht] Accumulated cycle startup energy entering the initial time step
+		double u_rsu0;				//[kWht] Accumulated receiver startup energy entering the initial time step
 		double pb_persist0;			//[hr]  Amount of time the cycle has been in its current operational state entering the initial time step
 		double rec_persist0;		//[hr]  Amount of time the receiver has been in its current operational state entering the initial time step
 

--- a/tcs/csp_dispatch.h
+++ b/tcs/csp_dispatch.h
@@ -77,7 +77,11 @@ public:
 	std::vector<double> w_lim;			//[kWe] Limit on net electricity production
 	std::vector<double> cap_frac;		// Fraction of gross capacity available
 	std::vector<double> eff_frac;		// Fraction of thermal efficiency available
-    C_csp_weatherreader *m_weather;       //Local copy of weather reader object
+	std::vector<double> dt_array;       // [hr] Dispatch time steps
+	std::vector<double> t_elapsed;		// [hr] Cumulative time elapsed at end of period t
+	std::vector<double> t_weight;		// Time weighting factor for period t
+
+    C_csp_weatherreader *m_weather;     //Local copy of weather reader object
 
 
     struct s_solver_params
@@ -127,7 +131,8 @@ public:
         bool is_pb_standby0;        //Power block is in standby at the initial time step
         double q_pb0;               //[kWt] Thermal power consumption in the cycle entering the initial time step
         double w_pb0;               //[kWe] Power production from the cycle entering the initial time step
-		int pb_persist0;			// Number of consecutive time steps cycle has been in its current operational state entering the initial time step
+		double pb_persist0;			//[hr]  Amount of time the cycle has been in its current operational state entering the initial time step
+		double rec_persist0;		//[hr]  Amount of time the receiver has been in its current operational state entering the initial time step
 
         double dt;                  //[hr] Time step
         double e_tes_init;          //[kWht] current stored energy capacity
@@ -162,14 +167,19 @@ public:
 		double w_cycle_pump;		//[kWe/kWt] Cycle HTF pumping power per thermal energy consumed
 
 		
-		double pb_max_rampup;       // [kWt] Maximum increase in cycle thermal input per dispatch timestep
-		double pb_max_rampdown;     // [kWt] Maximum decrease in cycle thermal input per dispatch timestep
-		int pb_minup;				// Minimum cycle up time (number of dispatch time steps)
-		int pb_mindown;				// Minimum cycle down time (number of dispatch time steps)
+		double pb_max_rampup;       // Maximum cycle ramp-up (fraction of capacity per hr)
+		double pb_max_rampdown;     // Maximum cycle ramp-down (fraction of capacity per hr)
+		double pb_rampup_violation_lim;       // Maximum allowable violation of cycle ramp-up constraint (fraction of capacity per hour)
+		double pb_rampdown_violation_lim;     // Maximum allowable violation of cycle ramp-down constraint (fraction of capacity per hour)
+
+		int pb_minup;				// Minimum cycle up time (hr)
+		int pb_mindown;				// Minimum cycle down time (hr)
 
 		int nstep_lookahead;		 // Number of steps in the lookahead window 
 
 		double e_tes_buffer;         // [kWht] Required storage buffer
+
+		bool is_uniform_dt;          // Are dispatch timesteps uniform?
 
         C_csp_solver_sim_info *siminfo;     //Pointer to existing simulation info object
         C_csp_collector_receiver *col_rec;   //Pointer to collector/receiver object
@@ -281,7 +291,7 @@ public:
 	} perm;
 
 
-    struct s_outputs
+	struct s_outputs
     {
         double objective;
         double objective_relaxed;
@@ -295,9 +305,9 @@ public:
         std::vector<double> tes_charge_expected;     //Expected thermal energy storage charge state
         std::vector<double> q_pb_startup;    //thermal power going to startup
         std::vector<double> q_rec_startup;   //thermal power going to startup
-        std::vector<double> w_pb_target;  //optimized electricity generation
-		std::vector<double> Qc; // startup power per period (limited based on fractional available capacity)
-        
+        std::vector<double> w_pb_target;	//optimized electricity generation
+		std::vector<double> Qc;				// startup power per period (limited based on fractional available capacity)
+
         util::matrix_t<double> wnet_lim_min; //minimum expected net power at time t before cycle gross falls before limit
         util::matrix_t<double> delta_rs;    //expected proportion of time step used for receiver start up
         
@@ -315,6 +325,9 @@ public:
         int presolve_nconstr;
         int presolve_nvar;
     } outputs;
+
+
+
     
     struct s_forecast_params
     {
@@ -365,8 +378,18 @@ public:
     //multi-variate forecasts
     //bool dispatch_forecast();
 
+	bool set_up_timestep_array(double horizon, const std::vector<double>& steplengths, const std::vector<double>& steplength_horizon);
+	bool translate_to_dispatch_timesteps(double wfstep, std::vector<double>& data);
+	bool translate_to_dispatch_timesteps(double wfstep, util::matrix_t<double>& data);
+	
+	template <typename T>
+	bool translate_from_dispatch_timesteps(double wfstep, std::vector<T>& data);
+	bool convert_outputs_to_weatherfile_timesteps(double wfstep);
+
+
     //Predict performance out nstep values. 
-    bool predict_performance(int step_start, int ntimeints, int divs_per_int);    
+    //bool predict_performance(int step_start, int ntimeints, int divs_per_int); 
+	bool predict_performance(int step_start, double horizon, double wfstep);
 
     //declare dispatch function in csp_dispatch.cpp
     bool optimize();

--- a/tcs/csp_dispatch.h
+++ b/tcs/csp_dispatch.h
@@ -167,10 +167,6 @@ public:
 		int pb_minup;				// Minimum cycle up time (number of dispatch time steps)
 		int pb_mindown;				// Minimum cycle down time (number of dispatch time steps)
 
-		int pb_onoff_perm;			 // Permanence of cycle on/off decisions (number of dispatch time steps)
-		int pb_onoff_lookahead_perm; // Permanence of cycle on/off decisions during look-ahead period (number of dispatch time steps)
-		int pb_level_perm;			 // Permanence of cycle operating level decisions (number of dispatch time steps)
-
 		int nstep_lookahead;		 // Number of steps in the lookahead window 
 
 		double e_tes_buffer;         // [kWht] Required storage buffer
@@ -270,6 +266,19 @@ public:
         } eff_table_load, eff_table_Tdb, wcondcoef_table_Tdb;        //Efficiency of the power cycle, condenser power coefs
         
     } params;
+
+	
+	struct s_perm  // Decision permanence variables (all specified in number of dispatch time steps)
+	{
+		int pb_onoff;			 // Permanence of cycle on/off decisions 
+		int pb_onoff_lookahead;  // Permanence of cycle on/off decisions during look-ahead period 
+		int pb_level;			 // Permanence of cycle operating level decisions 
+		int pb_level_lookahead;	 // Permanence of cycle operating level decisions during look-ahead period
+		
+		int rec_onoff;			  // Permanence of receiver on/off decisions 
+		int rec_onoff_lookahead;  // Permanence of receiver on/off decisions during look-ahead period 
+
+	} perm;
 
 
     struct s_outputs

--- a/tcs/csp_dispatch.h
+++ b/tcs/csp_dispatch.h
@@ -171,7 +171,9 @@ public:
 		int pb_onoff_lookahead_perm; // Permanence of cycle on/off decisions during look-ahead period (number of dispatch time steps)
 		int pb_level_perm;			 // Permanence of cycle operating level decisions (number of dispatch time steps)
 
-		int nstep_lookahead;		// Number of steps in the lookahead window 
+		int nstep_lookahead;		 // Number of steps in the lookahead window 
+
+		double e_tes_buffer;         // [kWht] Required storage buffer
 
         C_csp_solver_sim_info *siminfo;     //Pointer to existing simulation info object
         C_csp_collector_receiver *col_rec;   //Pointer to collector/receiver object
@@ -295,6 +297,8 @@ public:
         util::matrix_t<double> eta_pb_expected;     //Expected power cycle conversion efficiency (normalized)
         util::matrix_t<double> w_condf_expected;  //Expected condenser loss coefficient
 		util::matrix_t<double> f_pb_op_limit;  //[-] Maximum normalized cycle output
+
+		util::matrix_t<double> s_min;		// Allowable lower bound on storage [kWht]
 
         int solve_iter;             //Number of iterations required to solve
         int solve_state;

--- a/tcs/csp_dispatch.h
+++ b/tcs/csp_dispatch.h
@@ -127,6 +127,8 @@ public:
         bool is_pb_standby0;        //Power block is in standby at the initial time step
         double q_pb0;               //[kWt] Thermal power consumption in the cycle entering the initial time step
         double w_pb0;               //[kWe] Power production from the cycle entering the initial time step
+		int pb_persist0;			// Number of consecutive time steps cycle has been in its current operational state entering the initial time step
+
         double dt;                  //[hr] Time step
         double e_tes_init;          //[kWht] current stored energy capacity
         double e_tes_min;           //[kWht] minimum allowable energy capacity in TES
@@ -158,6 +160,12 @@ public:
 		double w_stow;				//[kWe-hr] Heliostat stow electricity requirement
 		double w_cycle_standby;		//[kWe] Cycle HTF pumping power during standby
 		double w_cycle_pump;		//[kWe/kWt] Cycle HTF pumping power per thermal energy consumed
+
+		
+		double pb_max_rampup;       // [kWt] Maximum increase in cycle thermal input per dispatch timestep
+		double pb_max_rampdown;     // [kWt] Maximum decrease in cycle thermal input per dispatch timestep
+		int pb_minup;				// Minimum cycle up time (number of dispatch time steps)
+		int pb_mindown;				// Minimum cycle down time (number of dispatch time steps)
 
         C_csp_solver_sim_info *siminfo;     //Pointer to existing simulation info object
         C_csp_collector_receiver *col_rec;   //Pointer to collector/receiver object
@@ -254,6 +262,12 @@ public:
         } eff_table_load, eff_table_Tdb, wcondcoef_table_Tdb;        //Efficiency of the power cycle, condenser power coefs
         
     } params;
+
+	struct s_permanence
+	{
+		int pb_onoff;    // Permanence of cycle on/off decisions (number of dispatch time steps)
+		int pb_level;    // Permanence of cycle operating level decisions (number of dispatch time steps)
+	} perm;
 
     struct s_outputs
     {

--- a/tcs/csp_dispatch.h
+++ b/tcs/csp_dispatch.h
@@ -167,6 +167,12 @@ public:
 		int pb_minup;				// Minimum cycle up time (number of dispatch time steps)
 		int pb_mindown;				// Minimum cycle down time (number of dispatch time steps)
 
+		int pb_onoff_perm;			 // Permanence of cycle on/off decisions (number of dispatch time steps)
+		int pb_onoff_lookahead_perm; // Permanence of cycle on/off decisions during look-ahead period (number of dispatch time steps)
+		int pb_level_perm;			 // Permanence of cycle operating level decisions (number of dispatch time steps)
+
+		int nstep_lookahead;		// Number of steps in the lookahead window 
+
         C_csp_solver_sim_info *siminfo;     //Pointer to existing simulation info object
         C_csp_collector_receiver *col_rec;   //Pointer to collector/receiver object
 		C_csp_power_cycle *mpc_pc;	// Pointer to csp power cycle class object
@@ -263,11 +269,6 @@ public:
         
     } params;
 
-	struct s_permanence
-	{
-		int pb_onoff;    // Permanence of cycle on/off decisions (number of dispatch time steps)
-		int pb_level;    // Permanence of cycle operating level decisions (number of dispatch time steps)
-	} perm;
 
     struct s_outputs
     {

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -952,13 +952,20 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 				
 				// update the optimization duration and full time horizon
 				double time_start = mc_kernel.mc_sim_info.ms_ts.m_time - baseline_step;
-						
-				if (mc_tou.mc_dispatch_params.m_horizon_update_frequency != mc_tou.mc_dispatch_params.m_optimize_frequency || disp_time_last < 0)
-					opt_horizon = mc_tou.mc_dispatch_params.m_optimize_horizon - (int)(((int)time_start % (3600 * mc_tou.mc_dispatch_params.m_horizon_update_frequency)) / 3600.);
+				if (mc_tou.mc_dispatch_params.m_is_run_single_opt)  // Run single optimization with the user-specified optimization horizon
+				{
+					opt_duration = mc_tou.mc_dispatch_params.m_optimize_horizon;
+				}
+				else
+				{
 
-				opt_duration = mc_tou.mc_dispatch_params.m_optimize_frequency;  // number of hours for which this optimized solution is applied		
-				if (disp_time_last < 0) // first optimization may have non-standard horizon
-					opt_duration -= (int)(time_start / 3600.) % mc_tou.mc_dispatch_params.m_optimize_frequency;
+					if (disp_time_last < 0 || mc_tou.mc_dispatch_params.m_horizon_update_frequency != mc_tou.mc_dispatch_params.m_optimize_frequency)  // Truncate first optimization horizon if starting time is not an integer multiple of the horizon update frequency
+						opt_horizon = mc_tou.mc_dispatch_params.m_optimize_horizon - (int)(((int)time_start % (3600 * mc_tou.mc_dispatch_params.m_horizon_update_frequency)) / 3600.);
+
+					opt_duration = mc_tou.mc_dispatch_params.m_optimize_frequency;  // number of hours for which this optimized solution is applied		
+					if (disp_time_last < 0) // first optimization may have non-standard horizon
+						opt_duration -= (int)(time_start / 3600.) % mc_tou.mc_dispatch_params.m_optimize_frequency;
+				}
 
 
 

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -1003,11 +1003,15 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 
 
                 //note the states of the power cycle and receiver
-                dispatch.params.is_pb_operating0 = mc_power_cycle.get_operating_state() == 1;
-                dispatch.params.is_pb_standby0 = mc_power_cycle.get_operating_state() == 2;
+                dispatch.params.is_pb_operating0 = mc_power_cycle.get_operating_state() == C_csp_power_cycle::ON;
+                dispatch.params.is_pb_standby0 = mc_power_cycle.get_operating_state() == C_csp_power_cycle::STANDBY;
+				dispatch.params.is_pb_startup0 = mc_power_cycle.get_operating_state() == C_csp_power_cycle::STARTUP;
                 dispatch.params.is_rec_operating0 = mc_collector_receiver.get_operating_state() == C_csp_collector_receiver::ON;
+				dispatch.params.is_rec_startup0 = mc_collector_receiver.get_operating_state() == C_csp_collector_receiver::STARTUP;
                 dispatch.params.q_pb0 = q_pb_last;
                 dispatch.params.w_pb0 = w_pb_last;
+				dispatch.params.u_csu0 = dispatch.params.is_pb_standby0 ? std::max(0.0, dispatch.params.e_pb_startup_cold - mc_power_cycle.get_remaining_startup_energy()) : 0.0; //kWht
+				dispatch.params.u_rsu0 = dispatch.params.is_rec_startup0 ? std::max(0.0, dispatch.params.e_rec_startup - mc_collector_receiver.get_remaining_startup_energy()) : 0.0; //kWht
 
                 if(dispatch.params.q_pb0 != dispatch.params.q_pb0 )
                     dispatch.params.q_pb0 = 0.;

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -1020,6 +1020,9 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 				dispatch.params.u_csu0 = dispatch.params.is_pb_standby0 ? std::max(0.0, dispatch.params.e_pb_startup_cold - mc_power_cycle.get_remaining_startup_energy()) : 0.0; //kWht
 				dispatch.params.u_rsu0 = dispatch.params.is_rec_startup0 ? std::max(0.0, dispatch.params.e_rec_startup - mc_collector_receiver.get_remaining_startup_energy()) : 0.0; //kWht
 
+				if (time_start - mc_kernel.get_sim_setup()->m_sim_time_start< 1.e-3)   
+					dispatch.params.q_pb0 = mc_tou.mc_dispatch_params.m_pc_q0*1000.;  // User-defined initial thermal input for first time step
+
                 if(dispatch.params.q_pb0 != dispatch.params.q_pb0 )
                     dispatch.params.q_pb0 = 0.;
             
@@ -1049,11 +1052,12 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 				// Note how long the cycle and receiver have been in their current operational state
 				dispatch.params.pb_persist0 = pc_state_persist; 
 				dispatch.params.rec_persist0 = rec_state_persist;
-				if (time_start < 1.e-6)
+				if (time_start - mc_kernel.get_sim_setup()->m_sim_time_start< 1.e-3)
 				{
-					dispatch.params.pb_persist0 = 1000.; // Set a large value for first optimiation so min up/down constraints are not limiting
-					dispatch.params.rec_persist0 = 1000.; 
+					dispatch.params.pb_persist0 = mc_tou.mc_dispatch_params.m_pc_persist_0; 
+					dispatch.params.rec_persist0 = mc_tou.mc_dispatch_params.m_rec_persist_0;
 				}
+
 
 
                 //-- Update time-indexed dispatch inputs

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -611,23 +611,26 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
             dispatch.params.wcondcoef_table_Tdb.add_point(T, wcond/m_cycle_W_dot_des); //fraction of rated gross gen
 		}
 
-
 		// Cycle ramp rates and min up/down time
 		dispatch.params.pb_max_rampup = mc_tou.mc_dispatch_params.m_pc_max_rampup*dispatch.params.dt*m_cycle_q_dot_des*1000.;  // [kWt] per dispatch time step
 		dispatch.params.pb_max_rampdown = mc_tou.mc_dispatch_params.m_pc_max_rampdown*dispatch.params.dt*m_cycle_q_dot_des*1000.;  // [kWt] per dispatch time step
 		dispatch.params.pb_minup = (int)ceil(mc_tou.mc_dispatch_params.m_pc_minup / dispatch.params.dt);		// Minimum cycle up time (number of dispatch time steps)
 		dispatch.params.pb_mindown = (int)ceil(mc_tou.mc_dispatch_params.m_pc_mindown / dispatch.params.dt);   // Minimum cycle down time (number of dispatch time steps)
-																					   
-		// Decision permanence
-		dispatch.params.pb_onoff_perm = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_perm / dispatch.params.dt);
-		dispatch.params.pb_level_perm = (int)ceil(mc_tou.mc_dispatch_params.m_pc_level_perm / dispatch.params.dt);
-
-		dispatch.params.nstep_lookahead = (int) (mc_tou.mc_dispatch_params.m_optimize_horizon - mc_tou.mc_dispatch_params.m_optimize_frequency) / dispatch.params.dt;
-		dispatch.params.pb_onoff_lookahead_perm = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_lookahead_perm / dispatch.params.dt);
-
-
+			
 		// Storage buffer
 		dispatch.params.e_tes_buffer = mc_tou.mc_dispatch_params.m_storage_buffer * dispatch.params.e_tes_max;
+
+		// Decision permanence
+		dispatch.perm.pb_onoff = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_perm / dispatch.params.dt);
+		dispatch.perm.pb_level = (int)ceil(mc_tou.mc_dispatch_params.m_pc_level_perm / dispatch.params.dt);
+		dispatch.perm.rec_onoff = (int)ceil(mc_tou.mc_dispatch_params.m_rec_onoff_perm / dispatch.params.dt);
+
+		dispatch.params.nstep_lookahead = (int) (mc_tou.mc_dispatch_params.m_optimize_horizon - mc_tou.mc_dispatch_params.m_optimize_frequency) / dispatch.params.dt;
+		dispatch.perm.pb_onoff_lookahead = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_lookahead_perm / dispatch.params.dt);
+		dispatch.perm.pb_level_lookahead = (int)ceil(mc_tou.mc_dispatch_params.m_pc_level_lookahead_perm / dispatch.params.dt);
+		dispatch.perm.rec_onoff_lookahead = (int)ceil(mc_tou.mc_dispatch_params.m_rec_onoff_lookahead_perm / dispatch.params.dt);
+
+		
 	}
 
 

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -1051,7 +1051,9 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 
 				
 				// Note how many "dispatch" time steps the cycle has been in it's current operational state
-				dispatch.params.pb_persist0 = (int)floor(pc_state_persist / dispatch.params.dt);
+				dispatch.params.pb_persist0 = (int)ceil(pc_state_persist / dispatch.params.dt);
+				if (time_start < 1.e-6)
+					dispatch.params.pb_persist0 = 1000.; // Set a large value for first optimiation so min up/down constraints are not limiting
 
 
                 //update the forecast scenarios, if needed

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -619,9 +619,11 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 		dispatch.params.pb_mindown = (int)ceil(mc_tou.mc_dispatch_params.m_pc_mindown / dispatch.params.dt);   // Minimum cycle down time (number of dispatch time steps)
 																					   
 		// Decision permanence
-		dispatch.perm.pb_onoff = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_perm / dispatch.params.dt);
-		dispatch.perm.pb_level = (int)ceil(mc_tou.mc_dispatch_params.m_pc_level_perm / dispatch.params.dt);
+		dispatch.params.pb_onoff_perm = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_perm / dispatch.params.dt);
+		dispatch.params.pb_level_perm = (int)ceil(mc_tou.mc_dispatch_params.m_pc_level_perm / dispatch.params.dt);
 
+		dispatch.params.nstep_lookahead = (int) (mc_tou.mc_dispatch_params.m_optimize_horizon - mc_tou.mc_dispatch_params.m_optimize_frequency) / dispatch.params.dt;
+		dispatch.params.pb_onoff_lookahead_perm = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_lookahead_perm / dispatch.params.dt);
 	}
 
 
@@ -942,6 +944,8 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
                 if( hour_now >= (8760 - opt_horizon) )
                     opt_horizon = (int)std::min((double)opt_horizon, (double)(8761-hour_now));
 
+				
+				dispatch.params.nstep_lookahead = (int) (opt_horizon - mc_tou.mc_dispatch_params.m_optimize_frequency) / dispatch.params.dt;
 
 
                 //message

--- a/tcs/csp_solver_core.cpp
+++ b/tcs/csp_solver_core.cpp
@@ -624,6 +624,10 @@ void C_csp_solver::Ssimulate(C_csp_solver::S_sim_setup & sim_setup)
 
 		dispatch.params.nstep_lookahead = (int) (mc_tou.mc_dispatch_params.m_optimize_horizon - mc_tou.mc_dispatch_params.m_optimize_frequency) / dispatch.params.dt;
 		dispatch.params.pb_onoff_lookahead_perm = (int)ceil(mc_tou.mc_dispatch_params.m_pc_onoff_lookahead_perm / dispatch.params.dt);
+
+
+		// Storage buffer
+		dispatch.params.e_tes_buffer = mc_tou.mc_dispatch_params.m_storage_buffer * dispatch.params.e_tes_max;
 	}
 
 

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -350,6 +350,9 @@ public:
 		std::vector<double> m_disp_steplength_array;
 		std::vector<double> m_disp_steplength_end_time;
 
+		double m_pc_q0;
+		double m_pc_persist_0;
+		double m_rec_persist_0;
 
         S_csp_tou_params()
         {
@@ -434,9 +437,9 @@ public:
 			m_disp_steplength_array.clear();    // Variable step lengths for real-time dispatch (min)
 			m_disp_steplength_end_time.clear(); // End time [hr] for application of each dispatch step length(min)
 
-			
-
-
+			m_pc_q0 = 0.0;   
+			m_pc_persist_0 = 1000.;
+			m_rec_persist_0 = 1000.;
         };
 
     } mc_dispatch_params;

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -332,6 +332,9 @@ public:
 
 		double m_pc_max_rampup;
 		double m_pc_max_rampdown;
+		double m_pc_rampup_violation_lim;
+		double m_pc_rampdown_violation_lim;
+
 		double m_pc_minup;
 		double m_pc_mindown;
 		double m_pc_onoff_perm;
@@ -341,6 +344,11 @@ public:
 		double m_pc_level_perm;
 		double m_pc_level_lookahead_perm;
 		double m_storage_buffer;
+
+		bool m_is_variable_disp_steps;
+		std::vector<double> m_disp_steplength_array;
+		std::vector<double> m_disp_steplength_end_time;
+
 
         S_csp_tou_params()
         {
@@ -404,8 +412,11 @@ public:
 			m_is_dispatch_targets = false;
 			m_is_disp_constr = false;
 
-			m_pc_max_rampup = 60.;		// Maximum cyle ramp-up (fraction of capacity per hr)
-			m_pc_max_rampdown = 60.;	// Maximum cyle ramp-up (fraction of capacity per hr)
+			m_pc_max_rampup = 60.;				// Maximum cycle ramp-up (fraction of capacity per hour)
+			m_pc_max_rampdown = 60.;			// Maximum cycle ramp-up (fraction of capacity per hour)
+			m_pc_rampup_violation_lim = 60.;   // Maximum allowable violation of cycle ramp-up constraint (fraction of capacity per hour)
+			m_pc_rampdown_violation_lim = 60.; // Maximum allowable violation of cycle ramp-down constraint (fraction of capacity per hour)
+			
 			m_pc_minup = 0.;			// Minimum cycle up time (hr)
 			m_pc_mindown = 0.;          // Minimum cycle down time (hr)
 			m_pc_onoff_perm = 0.;       // Cycle binary on/off decision permanence (hr)
@@ -416,6 +427,11 @@ public:
 			m_rec_onoff_lookahead_perm = 0.;  // Receiver binary on/off decision permanence during look-ahead window (hr)
 			
 			m_storage_buffer = 0.0;			 // Dispatch storage buffer (fraction of capacity)
+			 
+			m_is_variable_disp_steps = false;	// Use variable step lengths in dispatch model? 
+			m_disp_steplength_array.clear();    // Variable step lengths for real-time dispatch (min)
+			m_disp_steplength_end_time.clear(); // End time [hr] for application of each dispatch step length(min)
+
 
         };
 

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -583,6 +583,7 @@ public:
     virtual double get_min_power_delivery() = 0;    //MWt
 	virtual double get_tracking_power() = 0;		//MWe
 	virtual double get_col_startup_power() = 0;		//MWe-hr
+	virtual double get_remaining_startup_energy() = 0; //kWh
 
 	virtual void off(const C_csp_weatherreader::S_outputs &weather,
 		const C_csp_solver_htf_1state &htf_state_in,
@@ -731,6 +732,7 @@ public:
     virtual double get_hot_startup_energy() = 0;    //[MWh]
     virtual double get_max_thermal_power() = 0;     //MW
     virtual double get_min_thermal_power() = 0;     //MW
+	virtual double get_remaining_startup_energy() = 0; //kWht
 	virtual void get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max) = 0;	//[-] Normalized over design power
     virtual double get_efficiency_at_TPH(double T_degC, double P_atm, double relhum_pct, double *w_dot_condenser=0) = 0; //-
     virtual double get_efficiency_at_load(double load_frac, double *w_dot_condenser=0) = 0;

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -344,7 +344,8 @@ public:
 		double m_pc_level_perm;
 		double m_pc_level_lookahead_perm;
 		double m_storage_buffer;
-
+		
+		bool m_is_run_single_opt;
 		bool m_is_variable_disp_steps;
 		std::vector<double> m_disp_steplength_array;
 		std::vector<double> m_disp_steplength_end_time;
@@ -428,9 +429,12 @@ public:
 			
 			m_storage_buffer = 0.0;			 // Dispatch storage buffer (fraction of capacity)
 			 
+			m_is_run_single_opt = false;		// Run only a single optimziation horizon, overriding all other specifications of simulation end time or optimization frequency
 			m_is_variable_disp_steps = false;	// Use variable step lengths in dispatch model? 
 			m_disp_steplength_array.clear();    // Variable step lengths for real-time dispatch (min)
 			m_disp_steplength_end_time.clear(); // End time [hr] for application of each dispatch step length(min)
+
+			
 
 
         };

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -335,6 +335,7 @@ public:
 		double m_pc_minup;
 		double m_pc_mindown;
 		double m_pc_onoff_perm;
+		double m_pc_onoff_lookahead_perm;
 		double m_pc_level_perm;
 
 
@@ -400,12 +401,14 @@ public:
 			m_is_dispatch_targets = false;
 			m_is_disp_constr = false;
 
-			double m_pc_max_rampup = 60.;    // Maximum cyle ramp-up (fraction of capacity per hr)
-			double m_pc_max_rampdown = 60.;  // Maximum cyle ramp-up (fraction of capacity per hr)
-			double m_pc_minup = 0.;			  // Minimum cycle up time (hr)
-			double m_pc_mindown = 0.;         // Minimum cycle down time (hr)
-			double m_pc_onoff_perm = 0.;      // Cycle binary on/off decision permanence (hr)
-			double m_pc_level_perm = 0.;      // Cycle operating level decision permanence (hr)
+			m_pc_max_rampup = 60.;		// Maximum cyle ramp-up (fraction of capacity per hr)
+			m_pc_max_rampdown = 60.;	// Maximum cyle ramp-up (fraction of capacity per hr)
+			m_pc_minup = 0.;			// Minimum cycle up time (hr)
+			m_pc_mindown = 0.;          // Minimum cycle down time (hr)
+			m_pc_onoff_perm = 0.;       // Cycle binary on/off decision permanence (hr)
+			m_pc_level_perm = 0.;       // Cycle operating level decision permanence (hr)
+			
+			m_pc_onoff_lookahead_perm = 0.;  // Cycle binary on/off decision permanence during look-ahead window (hr)
 
         };
 

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -337,6 +337,7 @@ public:
 		double m_pc_onoff_perm;
 		double m_pc_onoff_lookahead_perm;
 		double m_pc_level_perm;
+		double m_storage_buffer;
 
 
         S_csp_tou_params()
@@ -409,6 +410,7 @@ public:
 			m_pc_level_perm = 0.;       // Cycle operating level decision permanence (hr)
 			
 			m_pc_onoff_lookahead_perm = 0.;  // Cycle binary on/off decision permanence during look-ahead window (hr)
+			m_storage_buffer = 0.0;			 // Dispatch storage buffer (fraction of capacity)
 
         };
 

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -330,6 +330,14 @@ public:
 		std::vector<double> m_disp_cap_constr;
 		std::vector<double> m_disp_eff_constr;
 
+		double m_pc_max_rampup;
+		double m_pc_max_rampdown;
+		double m_pc_minup;
+		double m_pc_mindown;
+		double m_pc_onoff_perm;
+		double m_pc_level_perm;
+
+
         S_csp_tou_params()
         {
             m_isleapyear = false;
@@ -391,6 +399,14 @@ public:
 
 			m_is_dispatch_targets = false;
 			m_is_disp_constr = false;
+
+			double m_pc_max_rampup = 60.;    // Maximum cyle ramp-up (fraction of capacity per hr)
+			double m_pc_max_rampdown = 60.;  // Maximum cyle ramp-up (fraction of capacity per hr)
+			double m_pc_minup = 0.;			  // Minimum cycle up time (hr)
+			double m_pc_mindown = 0.;         // Minimum cycle down time (hr)
+			double m_pc_onoff_perm = 0.;      // Cycle binary on/off decision permanence (hr)
+			double m_pc_level_perm = 0.;      // Cycle operating level decision permanence (hr)
+
         };
 
     } mc_dispatch_params;

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -853,6 +853,7 @@ public:
 			DISPATCH_PRES_NCONSTR,      //[-] Number of constraint relationships in dispatch model formulation
 			DISPATCH_PRES_NVAR,         //[-] Number of variables in dispatch model formulation
 			DISPATCH_SOLVE_TIME,        //[sec]   Time required to solve the dispatch model at each instance
+			DISPATCH_QPBTARGET_EXPECT,        //[MWt] Power cycle energy consumption in dispatch model
 
 			// **************************************************************
 			//      Outputs that are reported as weighted averages if 

--- a/tcs/csp_solver_core.h
+++ b/tcs/csp_solver_core.h
@@ -336,9 +336,11 @@ public:
 		double m_pc_mindown;
 		double m_pc_onoff_perm;
 		double m_pc_onoff_lookahead_perm;
+		double m_rec_onoff_perm;
+		double m_rec_onoff_lookahead_perm;
 		double m_pc_level_perm;
+		double m_pc_level_lookahead_perm;
 		double m_storage_buffer;
-
 
         S_csp_tou_params()
         {
@@ -407,9 +409,12 @@ public:
 			m_pc_minup = 0.;			// Minimum cycle up time (hr)
 			m_pc_mindown = 0.;          // Minimum cycle down time (hr)
 			m_pc_onoff_perm = 0.;       // Cycle binary on/off decision permanence (hr)
-			m_pc_level_perm = 0.;       // Cycle operating level decision permanence (hr)
+			m_pc_onoff_lookahead_perm = 0.;   // Cycle binary on/off decision permanence during look-ahead window (hr)
+			m_pc_level_perm = 0.;			  // Cycle operating level decision permanence (hr)
+			m_pc_level_perm = 0.;			  // Cycle operating level decision permanence during look-ahead window (hr)
+			m_rec_onoff_perm = 0.;			  // Receiver binary on/off decision permanence (hr)
+			m_rec_onoff_lookahead_perm = 0.;  // Receiver binary on/off decision permanence during look-ahead window (hr)
 			
-			m_pc_onoff_lookahead_perm = 0.;  // Cycle binary on/off decision permanence during look-ahead window (hr)
 			m_storage_buffer = 0.0;			 // Dispatch storage buffer (fraction of capacity)
 
         };

--- a/tcs/csp_solver_gen_collector_receiver.cpp
+++ b/tcs/csp_solver_gen_collector_receiver.cpp
@@ -396,6 +396,12 @@ double C_csp_gen_collector_receiver::get_col_startup_power()
 	return std::numeric_limits<double>::quiet_NaN(); //MWe-hr
 }
 
+double C_csp_gen_collector_receiver::get_remaining_startup_energy()
+{
+	throw(C_csp_exception("C_csp_gen_collector_receiver::get_remaining_startup_energy() is not complete"));
+	return std::numeric_limits<double>::quiet_NaN(); //kWh
+}
+
 void C_csp_gen_collector_receiver::on(const C_csp_weatherreader::S_outputs &weather,
 	const C_csp_solver_htf_1state &htf_state_in,
 	double field_control,

--- a/tcs/csp_solver_gen_collector_receiver.h
+++ b/tcs/csp_solver_gen_collector_receiver.h
@@ -152,6 +152,7 @@ public:
 	virtual double get_min_power_delivery();    //MWt
 	virtual double get_tracking_power();		//MWe
 	virtual double get_col_startup_power();		//MWe-hr
+	virtual double get_remaining_startup_energy();		//kWh
 
 	virtual void off(const C_csp_weatherreader::S_outputs &weather,
 		const C_csp_solver_htf_1state &htf_state_in,

--- a/tcs/csp_solver_lf_dsg_collector_receiver.cpp
+++ b/tcs/csp_solver_lf_dsg_collector_receiver.cpp
@@ -1078,6 +1078,12 @@ double C_csp_lf_dsg_collector_receiver::get_col_startup_power()
 	return std::numeric_limits<double>::quiet_NaN(); //MWe-hr
 }
 
+double C_csp_lf_dsg_collector_receiver::get_remaining_startup_energy()
+{
+	throw(C_csp_exception("C_csp_lf_dsg_collector_receiver::get_remaining_startup_energy() is not complete"));
+	return std::numeric_limits<double>::quiet_NaN(); //MWe-hr
+}
+
 int C_csp_lf_dsg_collector_receiver::C_mono_eq_freeze_prot_E_bal::operator()(double T_cold_in /*K*/, double *E_loss_balance /*-*/)
 {
 	// Call energy balance with updated timestep and temperature info

--- a/tcs/csp_solver_lf_dsg_collector_receiver.h
+++ b/tcs/csp_solver_lf_dsg_collector_receiver.h
@@ -416,6 +416,7 @@ public:
 	virtual double get_min_power_delivery();    //MWt
 	virtual double get_tracking_power();		//MWe
 	virtual double get_col_startup_power();		//MWe-hr
+	virtual double get_remaining_startup_energy();		//kWh
 
 	virtual void off(const C_csp_weatherreader::S_outputs &weather,
 		const C_csp_solver_htf_1state &htf_state_in,

--- a/tcs/csp_solver_mspt_collector_receiver.cpp
+++ b/tcs/csp_solver_mspt_collector_receiver.cpp
@@ -158,6 +158,11 @@ double C_csp_mspt_collector_receiver::get_col_startup_power()
 	return mc_pt_heliostatfield.ms_params.m_p_start * mc_pt_heliostatfield.ms_params.m_N_hel *1.e-3;	//MWe-hr
 }
 
+double C_csp_mspt_collector_receiver::get_remaining_startup_energy()
+{
+	return mc_mspt_receiver_222.get_remaining_startup_energy()/1000.;  //kWjt
+}
+
 
 void C_csp_mspt_collector_receiver::call(const C_csp_weatherreader::S_outputs &weather,
 	const C_csp_solver_htf_1state &htf_state_in,

--- a/tcs/csp_solver_mspt_collector_receiver.h
+++ b/tcs/csp_solver_mspt_collector_receiver.h
@@ -100,6 +100,7 @@ public:
     virtual double get_min_power_delivery();    //MWt
 	virtual double get_tracking_power();		//MWe
 	virtual double get_col_startup_power();		//MWe-hr
+	virtual double get_remaining_startup_energy();		//kWh
 
     virtual void off(const C_csp_weatherreader::S_outputs &weather,
 		const C_csp_solver_htf_1state &htf_state_in,

--- a/tcs/csp_solver_mspt_receiver_222.cpp
+++ b/tcs/csp_solver_mspt_receiver_222.cpp
@@ -132,6 +132,7 @@ C_mspt_receiver_222::C_mspt_receiver_222()
 	m_ncall = -1;
 
 	m_mode_initial = -1;
+	m_E_su_accum_init = 0.0;
 }
 
 void C_mspt_receiver_222::init()
@@ -230,6 +231,12 @@ void C_mspt_receiver_222::init()
 	{
 		m_E_su_prev = m_q_rec_des * m_rec_qf_delay;	//[W-hr] Startup energy
 		m_t_su_prev = m_rec_su_delay;				//[hr] Startup time requirement
+		if (m_mode_initial == C_csp_collector_receiver::STARTUP)
+		{
+			double startup_fraction = m_E_su_accum_init * 1.e6 / (m_q_rec_des * m_rec_qf_delay);
+			m_E_su_prev = std::fmax(0.0, m_q_rec_des * m_rec_qf_delay - m_E_su_accum_init * 1.e6);
+			m_t_su_prev = std::fmax(0.0, m_rec_su_delay * (1.0 - startup_fraction));  // Assume the same initial fraction of startup time and startup energy
+		}
 	}
 	else
 	{

--- a/tcs/csp_solver_mspt_receiver_222.cpp
+++ b/tcs/csp_solver_mspt_receiver_222.cpp
@@ -1071,6 +1071,11 @@ int C_mspt_receiver_222::get_operating_state()
 	return m_mode_prev;
 }
 
+double C_mspt_receiver_222::get_remaining_startup_energy()
+{
+	return m_E_su_prev;
+}
+
 void C_mspt_receiver_222::clear_outputs()
 {
 	ms_outputs.m_m_dot_salt_tot = 

--- a/tcs/csp_solver_mspt_receiver_222.h
+++ b/tcs/csp_solver_mspt_receiver_222.h
@@ -260,6 +260,8 @@ public:
 
     HTFProperties *get_htf_property_object();
 
+	double get_remaining_startup_energy();
+
 };
 
 

--- a/tcs/csp_solver_mspt_receiver_222.h
+++ b/tcs/csp_solver_mspt_receiver_222.h
@@ -149,6 +149,7 @@ public:
 	double m_A_sf;					//[m2]
 
 	int m_mode_initial;
+	double m_E_su_accum_init;    //Initial accumulated startup energy [MWht]
 
 	// 8.10.2015 twn: add tower piping thermal losses to receiver performance
 	double m_pipe_loss_per_m;		//[Wt/m]

--- a/tcs/csp_solver_pc_Rankine_indirect_224.cpp
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.cpp
@@ -447,6 +447,11 @@ double C_pc_Rankine_indirect_224::get_min_thermal_power()     //MW
     return ms_params.m_cycle_cutoff_frac * ms_params.m_P_ref / ms_params.m_eta_ref*1.e-3;    //MWh
 }
 
+double C_pc_Rankine_indirect_224::get_remaining_startup_energy()     //kWht
+{
+	return m_startup_energy_remain_prev;
+}
+
 double C_pc_Rankine_indirect_224::get_max_q_pc_startup()
 {
 	if( m_startup_time_remain_prev > 0.0 )

--- a/tcs/csp_solver_pc_Rankine_indirect_224.cpp
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.cpp
@@ -368,6 +368,12 @@ void C_pc_Rankine_indirect_224::init(C_csp_power_cycle::S_solved_params &solved_
 	{
 		m_startup_energy_remain_prev = m_startup_energy_required;	//[kW-hr]
 		m_startup_time_remain_prev = ms_params.m_startup_time;		//[hr]
+		
+	}
+	else if (m_standby_control_prev == C_csp_power_cycle::STARTUP_CONTROLLED || m_standby_control_prev == C_csp_power_cycle::STARTUP)
+	{
+		m_startup_energy_remain_prev = std::fmax(0.0, m_startup_energy_required - ms_params.m_startup_energy_accum_init * 1000.);
+		m_startup_time_remain_prev = std::fmax(0.0, ms_params.m_startup_time - ms_params.m_startup_energy_accum_init / m_q_dot_design);
 	}
 	else
 	{

--- a/tcs/csp_solver_pc_Rankine_indirect_224.h
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.h
@@ -234,6 +234,7 @@ public:
     virtual double get_hot_startup_energy();    //[MWh]
     virtual double get_max_thermal_power();     //MW
     virtual double get_min_thermal_power();     //MW
+	virtual double get_remaining_startup_energy(); //kWht
 	virtual void get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max);	//[-] Normalized over design power
 	virtual double get_efficiency_at_TPH(double T_degC, double P_atm, double relhum_pct, double *w_dot_condenser = 0);
     virtual double get_efficiency_at_load(double load_frac, double *w_dot_condenser=0);

--- a/tcs/csp_solver_pc_Rankine_indirect_224.h
+++ b/tcs/csp_solver_pc_Rankine_indirect_224.h
@@ -157,6 +157,7 @@ public:
 		double m_htf_pump_coef;		//[kW/kg/s] Pumping power to move 1 kg/s of HTF through power cycle
 
 		int m_mode_initial;			//Operating mode at start of simulation
+		double m_startup_energy_accum_init;  // [MWht] Initial accumulated startup energy at start of the simulation 
 
 		int m_pc_fl;				//[-] integer flag identifying Heat Transfer Fluid (HTF) in power block {1-27}
 		util::matrix_t<double> m_pc_fl_props;
@@ -212,6 +213,8 @@ public:
 				m_T_amb_low = m_T_amb_high =
 				m_m_dot_htf_low = m_m_dot_htf_high =				
 				m_W_dot_cooling_des = m_m_dot_water_des = std::numeric_limits<double>::quiet_NaN();
+
+			m_startup_energy_accum_init = 0.0;
 		}
 	};
 

--- a/tcs/csp_solver_pc_gen.cpp
+++ b/tcs/csp_solver_pc_gen.cpp
@@ -225,6 +225,13 @@ double C_pc_gen::get_min_thermal_power()
 
 	return std::numeric_limits<double>::quiet_NaN();	//[MW]
 }
+double C_pc_gen::get_remaining_startup_energy()
+{
+	throw(C_csp_exception("C_csp_gen_pc::get_remaining_startup_energy() is not complete"));
+
+	return std::numeric_limits<double>::quiet_NaN();	//[MW]
+}
+
 void C_pc_gen::get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max)
 {
 	throw(C_csp_exception("C_csp_gen_pc::get_max_power_output_operation_constraints() is not complete"));

--- a/tcs/csp_solver_pc_gen.h
+++ b/tcs/csp_solver_pc_gen.h
@@ -135,6 +135,7 @@ public:
 	virtual double get_hot_startup_energy();    //[MWh]
 	virtual double get_max_thermal_power();     //MW
 	virtual double get_min_thermal_power();     //MW
+	virtual double get_remaining_startup_energy();     //kWh
 	virtual void get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max);	//[-] Normalized over design power
 	virtual double get_efficiency_at_TPH(double T_degC, double P_atm, double relhum_pct, double *w_dot_condenser=0);
 	virtual double get_efficiency_at_load(double load_frac, double *w_dot_condenser=0);

--- a/tcs/csp_solver_pc_heat_sink.cpp
+++ b/tcs/csp_solver_pc_heat_sink.cpp
@@ -202,6 +202,10 @@ double C_pc_heat_sink::get_min_thermal_power()
 {
 	return 0.0;		//[MWt]
 }
+double C_pc_heat_sink::get_remaining_startup_energy()
+{
+	return 0.0;		//[MWt]
+}
 
 void C_pc_heat_sink::get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max)
 {

--- a/tcs/csp_solver_pc_heat_sink.h
+++ b/tcs/csp_solver_pc_heat_sink.h
@@ -121,6 +121,7 @@ public:
 	virtual double get_hot_startup_energy();    //[MWh]
 	virtual double get_max_thermal_power();     //MW
 	virtual double get_min_thermal_power();     //MW
+	virtual double get_remaining_startup_energy();     //MW
 	virtual void get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max);	//[-] Normalized over design power
 	virtual double get_efficiency_at_TPH(double T_degC, double P_atm, double relhum_pct, double *w_dot_condenser=0);
 	virtual double get_efficiency_at_load(double load_frac, double *w_dot_condenser=0);

--- a/tcs/csp_solver_pc_sco2.cpp
+++ b/tcs/csp_solver_pc_sco2.cpp
@@ -205,6 +205,10 @@ double C_pc_sco2::get_min_thermal_power()
 {
 	return m_q_dot_min;		//[MWt]
 }
+double C_pc_sco2::get_remaining_startup_energy()
+{
+	return m_startup_energy_remain_prev;		//[MWt]
+}
 
 void C_pc_sco2::get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max)
 {

--- a/tcs/csp_solver_pc_sco2.h
+++ b/tcs/csp_solver_pc_sco2.h
@@ -137,6 +137,7 @@ public:
 	virtual double get_hot_startup_energy();    //[MWh]
 	virtual double get_max_thermal_power();     //MW
 	virtual double get_min_thermal_power();     //MW
+	virtual double get_remaining_startup_energy();     //kWh
 	virtual void get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max);	//[-] Normalized over design power
 	virtual double get_efficiency_at_TPH(double T_degC, double P_atm, double relhum_pct, double *w_dot_condenser=0);
 	virtual double get_efficiency_at_load(double load_frac, double *w_dot_condenser=0);

--- a/tcs/csp_solver_pc_steam_heat_sink.cpp
+++ b/tcs/csp_solver_pc_steam_heat_sink.cpp
@@ -215,6 +215,10 @@ double C_pc_steam_heat_sink::get_min_thermal_power()
 	return 0.0;		//[MWt]
 }
 
+double C_pc_steam_heat_sink::get_remaining_startup_energy()
+{
+	return 0.0;		//[MWt]
+}
 double C_pc_steam_heat_sink::get_htf_pumping_parasitic_coef()
 {
 	return 0.0;	// kWe/kWt

--- a/tcs/csp_solver_pc_steam_heat_sink.h
+++ b/tcs/csp_solver_pc_steam_heat_sink.h
@@ -120,6 +120,7 @@ public:
 	virtual double get_hot_startup_energy();    //[MWh]
 	virtual double get_max_thermal_power();     //MW
 	virtual double get_min_thermal_power();     //MW
+	virtual double get_remaining_startup_energy();     //kWh
 	virtual void get_max_power_output_operation_constraints(double T_amb /*C*/, double & m_dot_HTF_ND_max, double & W_dot_ND_max);	//[-] Normalized over design power
 	virtual double get_efficiency_at_TPH(double T_degC, double P_atm, double relhum_pct, double *w_dot_condenser = 0);
 	virtual double get_efficiency_at_load(double load_frac, double *w_dot_condenser=0);

--- a/tcs/csp_solver_tou_block_schedules.cpp
+++ b/tcs/csp_solver_tou_block_schedules.cpp
@@ -272,7 +272,9 @@ void C_csp_tou_block_schedules::call(double time_s, C_csp_tou::S_csp_tou_outputs
 			throw(C_csp_exception(m_error_msg, "TOU timestep call"));
 		}
 		size_t nrecs_per_hour = nrecs / 8760;
-		int ndx = (int)((ceil(time_s / 3600.0 - 1.e-6) - 1) * nrecs_per_hour);
+		//int ndx = (int)((ceil(time_s / 3600.0 - 1.e-6) - 1) * nrecs_per_hour);
+		double time_per_rec = 3600. / (float)nrecs_per_hour;
+		int ndx = (int)(ceil(time_s / time_per_rec - 1.e-6) - 1);
 
 		if (ndx > (int)nrecs - 1 + (mc_dispatch_params.m_isleapyear ? 24 : 0) || ndx<0)
 		{

--- a/tcs/csp_solver_trough_collector_receiver.cpp
+++ b/tcs/csp_solver_trough_collector_receiver.cpp
@@ -857,6 +857,10 @@ double C_csp_trough_collector_receiver::get_col_startup_power()
 	return std::numeric_limits<double>::quiet_NaN();	//MWe-hr
 }
 
+double C_csp_trough_collector_receiver::get_remaining_startup_energy()
+{
+	return std::numeric_limits<double>::quiet_NaN();	//kWh
+}
 
 void C_csp_trough_collector_receiver::get_design_parameters(C_csp_collector_receiver::S_csp_cr_solved_params & solved_params)
 {

--- a/tcs/csp_solver_trough_collector_receiver.h
+++ b/tcs/csp_solver_trough_collector_receiver.h
@@ -448,6 +448,7 @@ public:
 	virtual double get_min_power_delivery();    //MWt
 	virtual double get_tracking_power();		//MWe
 	virtual double get_col_startup_power();		//MWe-hr
+	virtual double get_remaining_startup_energy();		//kWh
 
 	virtual int get_operating_state();
 	

--- a/tcs/csp_solver_two_tank_tes.cpp
+++ b/tcs/csp_solver_two_tank_tes.cpp
@@ -296,6 +296,8 @@ void C_storage_tank::energy_balance(double timestep /*s*/, double m_dot_in, doub
 
 		m_T_calc = a_coef / b_coef + (m_T_prev - a_coef / b_coef)*pow((timestep*c_coef / m_m_prev + 1), -b_coef / c_coef);
 		T_ave = a_coef / b_coef + m_m_prev*(m_T_prev - a_coef / b_coef) / ((c_coef - b_coef)*timestep)*(pow((timestep*c_coef / m_m_prev + 1.0), 1.0 -b_coef/c_coef) - 1.0);
+		if (timestep < 1.e-6)
+			T_ave = a_coef / b_coef + (m_T_prev - a_coef / b_coef)*pow((timestep*c_coef / m_m_prev + 1.0), -b_coef / c_coef);	// Limiting expression for small time step	
 		q_dot_loss = m_UA*(T_ave - T_amb)/1.E6;		//[MW]
 
 		if( m_T_calc < m_T_htr )
@@ -322,6 +324,8 @@ void C_storage_tank::energy_balance(double timestep /*s*/, double m_dot_in, doub
 
 		m_T_calc = a_coef / b_coef + (m_T_prev - a_coef / b_coef)*pow((timestep*c_coef / m_m_prev + 1), -b_coef / c_coef);
 		T_ave = a_coef / b_coef + m_m_prev*(m_T_prev - a_coef / b_coef) / ((c_coef - b_coef)*timestep)*(pow((timestep*c_coef / m_m_prev + 1.0), 1.0 -b_coef/c_coef) - 1.0);
+		if (timestep < 1.e-6)
+			T_ave = a_coef / b_coef + (m_T_prev - a_coef / b_coef)*pow((timestep*c_coef / m_m_prev + 1.0), -b_coef / c_coef);  // Limiting expression for small time step
 		q_dot_loss = m_UA*(T_ave - T_amb)/1.E6;		//[MW]
 
 	}
@@ -332,6 +336,8 @@ void C_storage_tank::energy_balance(double timestep /*s*/, double m_dot_in, doub
 
 		m_T_calc = c_coef / b_coef + (m_T_prev - c_coef / b_coef)*exp(-b_coef*timestep);
 		T_ave = c_coef/b_coef - (m_T_prev - c_coef/b_coef)/(b_coef*timestep)*(exp(-b_coef*timestep)-1.0);
+		if (timestep < 1.e-6)
+			T_ave = c_coef / b_coef + (m_T_prev - c_coef / b_coef)*exp(-b_coef * timestep);  // Limiting expression for small time step	
 		q_dot_loss = m_UA*(T_ave - T_amb)/1.E6;
 
 		if( m_T_calc < m_T_htr )
@@ -354,6 +360,8 @@ void C_storage_tank::energy_balance(double timestep /*s*/, double m_dot_in, doub
 
 		m_T_calc = c_coef / b_coef + (m_T_prev - c_coef / b_coef)*exp(-b_coef*timestep);
 		T_ave = c_coef / b_coef - (m_T_prev - c_coef / b_coef) / (b_coef*timestep)*(exp(-b_coef*timestep) - 1.0);
+		if (timestep < 1.e-6)
+			T_ave = c_coef / b_coef + (m_T_prev - c_coef / b_coef)*exp(-b_coef * timestep);  // Limiting expression for small time step	
 		q_dot_loss = m_UA*(T_ave - T_amb)/1.E6;		//[MW]
 	}
 }


### PR DESCRIPTION
Adds functionality to pass variable time-step inputs to the ampl dispatch optimization model
Adds optional ssc inputs for user-defined component initial states
Adds min up/down time constraints, ramp rate constraints, storage buffer, and decision "permanence" constraints to the lpsolve dispatch model (these will need to be changed for consistency with the new ampl real-time dispatch model)
