### PR TITLE
API additions

### DIFF
--- a/solarpilot/CoPilot_API.cpp
+++ b/solarpilot/CoPilot_API.cpp
@@ -902,42 +902,41 @@ SPEXPORT sp_number_t* sp_generate_simulation_days(sp_data_t p_data, int *nrecord
     SolarField* SF = &mc->solarfield;
     SimControl* SC = &mc->sim_control;
 
-    if (SF->getHeliostats()->size() == 0)
-    {
-        //no layout exists, so we should be calling the 'run_layout' method instead
-        std::string msg = "No layout exists, so the 'update_geometry' function cannot be executed. Please first create or import a layout using 'run_layout'.";
-        SC->message_callback(msg.c_str(), SC->message_callback_data);
-        return 0;
-    }
+    //if (SF->getHeliostats()->size() == 0)
+    //{
+    //    //no layout exists, so we should be calling the 'run_layout' method instead
+    //    std::string msg = "No layout exists, so the 'update_geometry' function cannot be executed. Please first create or import a layout using 'run_layout'.";
+    //    SC->message_callback(msg.c_str(), SC->message_callback_data);
+    //    return 0;
+    //}
 
-    ArrayString local_wfdat;
-    if (!_load_weather_file(V, local_wfdat))
-    {
-        std::string msg = "'update_geometry' function cannot find weather file.\n Please adjust desired file path or location to be consistent.";
-        SC->message_callback(msg.c_str(), SC->message_callback_data);
-        return false; //error
-    }
+    //ArrayString local_wfdat;
+    //if (!_load_weather_file(V, local_wfdat))
+    //{
+    //    std::string msg = "'update_geometry' function cannot find weather file.\n Please adjust desired file path or location to be consistent.";
+    //    SC->message_callback(msg.c_str(), SC->message_callback_data);
+    //    return false; //error
+    //}
 
-    interop::GenerateSimulationWeatherData(*V, V->sf.des_sim_detail.mapval(), local_wfdat);
+    //interop::GenerateSimulationWeatherData(*V, V->sf.des_sim_detail.mapval(), local_wfdat);
 
     WeatherData* wd = &V->sf.sim_step_data.Val();
     *nrecord = wd->_N_items;
 
-    sp_number_t* simsteps_out = new sp_number_t[6 * (*nrecord)];
+    *ncol = 7; 
+    
+    sp_number_t* simsteps_out = new sp_number_t[(*ncol) * (*nrecord)];
 
+    for (int i = 0; i < *nrecord; i++)
     {
-        *ncol = 7; 
-        for (int i = 0; i < *nrecord; i++)
-        {
-            int j = 0;
-            simsteps_out[i * *ncol + j++] = wd->Month.at(i);
-            simsteps_out[i * *ncol + j++] = wd->Day.at(i);
-            simsteps_out[i * *ncol + j++] = wd->Hour.at(i);
-            simsteps_out[i * *ncol + j++] = wd->DNI.at(i);
-            simsteps_out[i * *ncol + j++] = wd->T_db.at(i);
-            simsteps_out[i * *ncol + j++] = wd->V_wind.at(i);
-            simsteps_out[i * *ncol + j++] = wd->Step_weight.at(i);
-        }
+        int j = 0;
+        simsteps_out[i * *ncol + j++] = wd->Month.at(i);
+        simsteps_out[i * *ncol + j++] = wd->Day.at(i);
+        simsteps_out[i * *ncol + j++] = wd->Hour.at(i);
+        simsteps_out[i * *ncol + j++] = wd->DNI.at(i);
+        simsteps_out[i * *ncol + j++] = wd->T_db.at(i);
+        simsteps_out[i * *ncol + j++] = wd->V_wind.at(i);
+        simsteps_out[i * *ncol + j++] = wd->Step_weight.at(i);
     }
 
     return simsteps_out;

--- a/solarpilot/CoPilot_API.h
+++ b/solarpilot/CoPilot_API.h
@@ -80,6 +80,8 @@ extern "C" {
 
     SPEXPORT bool sp_drop_heliostat_template(sp_data_t p_data, const char* heliostat_name);
 
+    SPEXPORT sp_number_t* sp_generate_simulation_days(sp_data_t p_data, int* nrecord, int* ncol);
+
     SPEXPORT bool sp_update_geometry(sp_data_t p_data);
 
     SPEXPORT bool sp_generate_layout(sp_data_t p_data, int nthreads);
@@ -126,6 +128,9 @@ extern "C" {
     SPEXPORT bool sp_load_from_script(sp_data_t p_data, const char* sp_fname);
 
     SPEXPORT bool sp_dump_varmap(sp_data_t p_data, const char* sp_fname);
+
+    //SPEXPORT bool sp_export_soltrace(sp_data_t p_data, const char* sp_fname);
+    SPEXPORT void _sp_free_var(sp_number_t* m);
 
 #ifdef __cplusplus
 }

--- a/solarpilot/CoPilot_API.h
+++ b/solarpilot/CoPilot_API.h
@@ -89,9 +89,9 @@ extern "C" {
     SPEXPORT bool sp_assign_layout(sp_data_t p_data, sp_number_t* pvalues, int nrows, int ncols, int nthreads);
 
     //SPEXPORT sp_number_t* sp_get_layout_info(sp_data_t p_data, int* nhelio, int* ncol);
-    SPEXPORT sp_number_t* sp_get_layout_info(sp_data_t p_data, int* nhelio, int* ncol, bool get_corners);
+    SPEXPORT sp_number_t* sp_get_layout_info(sp_data_t p_data, int* nhelio, int* ncol, bool get_corners, bool get_optical_details);
 
-    SPEXPORT const char* sp_get_layout_header(sp_data_t p_data, bool get_corners);
+    SPEXPORT const char* sp_get_layout_header(sp_data_t p_data, bool get_corners, bool get_optical_details);
 
     SPEXPORT bool sp_simulate(sp_data_t p_data, int nthreads, bool update_aimpoints); //bool save_detail,
 

--- a/solarpilot/CoPilot_API.h
+++ b/solarpilot/CoPilot_API.h
@@ -129,7 +129,10 @@ extern "C" {
 
     SPEXPORT bool sp_dump_varmap(sp_data_t p_data, const char* sp_fname);
 
-    //SPEXPORT bool sp_export_soltrace(sp_data_t p_data, const char* sp_fname);
+    SPEXPORT bool sp_export_soltrace(sp_data_t p_data, const char* sp_fname);
+
+    SPEXPORT bool sp_load_soltrace_context(sp_data_t p_data, st_context_t* solt_cxt);
+
     SPEXPORT void _sp_free_var(sp_number_t* m);
 
 #ifdef __cplusplus

--- a/solarpilot/STObject.cpp
+++ b/solarpilot/STObject.cpp
@@ -682,7 +682,9 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 		return false;	//Error, should have been cleared earlier
 	}
 	else{	
-		nhtemp = (int)SF.getHeliostatTemplates()->size();
+		//nhtemp = (int)SF.getHeliostatTemplates()->size();
+		nhtemp = (int)helios.size();
+		OpticsList.reserve(nhtemp);
 		for(int i=0; i<nhtemp; i++){
 			OpticsList.push_back( new ST_OpticalPropertySet() );
 		}
@@ -694,10 +696,14 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 	//map the optics pointer to the heliostat template name
 	unordered_map<std::string, ST_OpticalPropertySet*> optics_map;
 
-	int ii=0;
-	for(htemp_map::iterator it = SF.getHeliostatTemplates()->begin(); it != SF.getHeliostatTemplates()->end(); it++){
-		Heliostat *H = it->second;
-		OpticsList.at(ii)->Name = (*H->getHeliostatName()).c_str();
+	for(int ii=0; ii<nhtemp; ii++)
+	{
+		//Heliostat *H = it->second;
+		Heliostat* H = helios.at(ii);
+		char hname[30];
+		sprintf(hname, "heliostat_%d", ii);
+		//OpticsList.at(ii)->Name = (*H->getHeliostatName()).c_str() + H->getId();
+		OpticsList.at(ii)->Name = hname;
 		optics_map[ OpticsList.at(ii)->Name ] = OpticsList.at(ii);
 		
 		/* 
@@ -795,7 +801,7 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 		OpticsList.at(ii)->Back.RMSSlopeError = 100.0;
 		OpticsList.at(ii)->Back.RMSSpecError = 0.;
 		
-		ii++;
+		//ii++;
 	}
 	
 	/*
@@ -901,7 +907,10 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 
 		char shape = Hv->is_round.mapval() == var_heliostat::IS_ROUND::ROUND ? 'c' : 'r';
 
-		string opticname = (*H->getHeliostatName()).c_str();
+		char hname[30];
+		sprintf(hname, "heliostat_%d", i);
+
+		string opticname = hname;
 
 		for(int j=0; j<ncantx; j++){
 			for(int k=0; k<ncanty; k++){

--- a/solarpilot/STObject.cpp
+++ b/solarpilot/STObject.cpp
@@ -690,19 +690,15 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 		}
 	}
 
-	//int *optic = new int[nhtemp];
-	//double grating[] = {0.,0.,0.};
-	
 	//map the optics pointer to the heliostat template name
 	unordered_map<std::string, ST_OpticalPropertySet*> optics_map;
 
 	for(int ii=0; ii<nhtemp; ii++)
 	{
-		//Heliostat *H = it->second;
 		Heliostat* H = helios.at(ii);
 		char hname[30];
 		sprintf(hname, "heliostat_%d", ii);
-		//OpticsList.at(ii)->Name = (*H->getHeliostatName()).c_str() + H->getId();
+
 		OpticsList.at(ii)->Name = hname;
 		optics_map[ OpticsList.at(ii)->Name ] = OpticsList.at(ii);
 		
@@ -715,6 +711,8 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 		*/
 		
 		double refl = H->getTotalReflectivity();	//reflectivity * soiling
+		//scale reflectance by attenuation for this heliostat
+		refl *= H->getEfficiencyAtten();
 		//Note that the reflected energy is also reduced by the fraction of inactive heliostat aperture. Since
 		//we input the actual heliostat dimensions into soltrace, apply this derate on the reflectivity.
 		var_heliostat *Hv = H->getVarMap();
@@ -875,10 +873,6 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 		return false;
 	}
 
-	/*for(int i=0; i<nh; i++){
-		h_stage->ElementList.push_back( new ST_Element() );
-	}*/
-	
 	//keep track of the heliostat area
 	double Ahtot=0.;
 	for(int i=0; i<nh; i++){
@@ -899,13 +893,23 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 		bool enabled = H->IsInLayout();
 		
 		sp_point *P; 
-		Vect *V;
 		P = H->getLocation();
-		V = H->getTrackVector();
-		
-		double zrot = R2D*Toolbox::ZRotationTransform(*V);
+		Vect V;
+		sp_point* aim = H->getAimPoint();
+		V.i = aim->x - P->x;
+		V.j = aim->y - P->y;
+		V.k = aim->z - P->z;
+		Toolbox::unitvect(V);
+		V.Add(sunvect);
+		V.Scale(0.5);
+		Toolbox::unitvect(V);
+
+		double zrot = R2D*Toolbox::ZRotationTransform(V);
 
 		char shape = Hv->is_round.mapval() == var_heliostat::IS_ROUND::ROUND ? 'c' : 'r';
+
+		double track_zen = std::acos(V.k);
+		double track_az = std::atan2(V.i, V.j);
 
 		char hname[30];
 		sprintf(hname, "heliostat_%d", i);
@@ -929,10 +933,10 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 					Toolbox::unitvect(Faim);
 
 					//Rotate to match heliostat rotation
-					Toolbox::rotation( H->getZenithTrack(), 0, Floc);
-					Toolbox::rotation( H->getZenithTrack(), 0, Faim);
-					Toolbox::rotation( H->getAzimuthTrack(), 2, Floc);
-					Toolbox::rotation( H->getAzimuthTrack(), 2, Faim);
+					Toolbox::rotation( track_zen, 0, Floc);
+					Toolbox::rotation( track_zen, 0, Faim);
+					Toolbox::rotation( track_az, 2, Floc);
+					Toolbox::rotation( track_az, 2, Faim);
 
 					element->Origin[0] = P->x + Floc.x;
 					element->Origin[1] = P->y + Floc.y;
@@ -948,9 +952,9 @@ bool ST_System::CreateSTSystem(SolarField &SF, Hvector &helios, Vect &sunvect){
 					element->Origin[1] = P->y;
 					element->Origin[2] = P->z;
 				
-					element->AimPoint[0] = P->x + V->i*1000.;
-					element->AimPoint[1] = P->y + V->j*1000.;
-					element->AimPoint[2] = P->z + V->k*1000.;
+					element->AimPoint[0] = P->x + V.i*1000.;
+					element->AimPoint[1] = P->y + V.j*1000.;
+					element->AimPoint[2] = P->z + V.k*1000.;
 				}
 
 				//element->ZRot = 0.;

--- a/solarpilot/SolarField.cpp
+++ b/solarpilot/SolarField.cpp
@@ -3985,6 +3985,9 @@ void SolarField::calcAllAimPoints(Vect &Sun, sim_params &P) //bool force_simple,
             break;
 		}
 
+		//update the tracking vector after updating the aimpoint
+		_heliostats.at(i)->updateTrackVector(Sun);
+
 
 		//Update the progress bar
         if(! P.is_layout )

--- a/solarpilot/interop.cpp
+++ b/solarpilot/interop.cpp
@@ -1557,7 +1557,7 @@ void interop::CreateResultsTable(sim_result& result, grid_emulator_base& table)
 		{
 			table.AddRow(id++, "Cloudiness efficiency", "%", 100. * result.eff_cloud.wtmean, 2);
 			table.AddRow(id++, "Shadowing and Cosine efficiency", "%", 100. * result.eff_cosine.wtmean, 2);
-			table.AddRow(id++, "Reflection efficiency", "%", 100. * result.eff_reflect.wtmean, 2);
+			table.AddRow(id++, "Reflection and Attenuation efficiency", "%", 100. * result.eff_reflect.wtmean, 2);
 			table.AddRow(id++, "Blocking efficiency", "%", 100. * result.eff_blocking.wtmean, 2);
 			table.AddRow(id++, "Image intercept efficiency", "%", 100. * result.eff_intercept.wtmean, 2);
 			table.AddRow(id++, "Absorption efficiency", "%", 100. * result.eff_absorption.wtmean, 2);


### PR DESCRIPTION
This PR includes several improvements to the CoPylot API that better support SolTrace integration. 

- SolTrace simulation previously did not include attenuation loss. This loss is now accounted for by assigning unique optical properties to each heliostat in the field. The loss is applied by modifying the optical reflectivity to be the product (reflectivity * soiling * attenuation * structure mirror fraction).  
- A new function is added to the API that exports layout simulation weather steps and associated data. 
- Additional information on heliostat optics is reported in the summary results and detail results API calls.
